### PR TITLE
Remove last update date in pages to make builds not fail

### DIFF
--- a/config/presets.ts
+++ b/config/presets.ts
@@ -22,7 +22,6 @@ const presets: PresetConfig[] = [
         sidebarPath: require.resolve("./sidebarsConfig"),
         docItemComponent: "@theme/ApiItem",
         sidebarItemsGenerator: sidebarGenerator,
-        showLastUpdateTime: true,
         remarkPlugins: [
           [require("@docusaurus/remark-plugin-npm2yarn"), { sync: true }],
           [require("../plugins/remark-plugin-yaml-and-json"), { sync: false }],


### PR DESCRIPTION
# Other Changes Pull Request

## Description

Remove last update date in pages to make builds not fail.

## Related Issue

Link to the issue here: [Issue #](

## Type of Change

- [ ] Docusaurus update/maintenance
    - [ ] Dependency update
    - [ ] Configuration change
    - [ ] Plugin update
    - [ ] Bug fix
    - [ ] Style Change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Build process update
- [x] Other (please specify):

<!-- If you selected "Docusaurus update/maintenance", please fill out the following section -->
### Docusaurus Update/Maintenance Details
- **Dependency Update**: Name and version of the updated dependency
- **Configuration Changed**: Describe the configuration changes made
- **Plugin Update**: Name and version of the updated plugin
- **Bug Fix**: Describe the bug that was fixed and the solution
- **Style Change**: Describe the style changes implemented 

### Other Change Details (if applicable)
- **Description**: Remove last update date in docs

## Motivation and Context

Why is this change required? What problem does it solve?

## Checklist:

- [ ] My changes follow the [style guidelines](https://github.com/signalwire/signalwire-docs/wiki/Style-Guidelines) of this project
- [ ] I have performed a self-review of my changes
- [ ] My changes generate no new warnings
- [ ] Builds successfully locally 

## Additional Notes

Add any other context about the pull request here.
