### PR TITLE
Replace `id.signalwire.com/onboarding` links with `signalwire.com/signup`

### DIFF
--- a/config/navbar.ts
+++ b/config/navbar.ts
@@ -171,7 +171,7 @@ const navbar: NavbarItem[] = [
   },
 
   {
-    href: "https://id.signalwire.com",
+    href: "https://signalwire.com/signin",
     label: "Dashboard",
     position: "right",
     className: "dashboard-navbar-link",

--- a/docs/events/livewire/smart-biz-ai/index.mdx
+++ b/docs/events/livewire/smart-biz-ai/index.mdx
@@ -70,7 +70,7 @@ sequenceDiagram
 
         Before getting started, please make sure you have the following prerequisites.
 
-        - Sign up for a free [SignalWire Space](https://id.signalwire.com/onboarding)
+        - Sign up for a free [SignalWire Space](https://signalwire.com/signup)
         - Install [Docker Desktop](https://www.docker.com/products/docker-desktop/)
         - Buy a [SignalWire Phone Number](/platform/phone-numbers/getting-started/buying-a-phone-number)
         - Create a free [ngrok account](https://ngrok.com/)

--- a/docs/events/livewire/swaig-plus-zendesk/index.mdx
+++ b/docs/events/livewire/swaig-plus-zendesk/index.mdx
@@ -67,7 +67,7 @@ import { Card, CardGroup } from "@site/src/components/Extras/Card";
 ### Prerequisites
 
 - A **Zendesk** account with admin access
-- A free [SignalWire account](https://id.signalwire.com/onboarding)
+- A free [SignalWire account](https://signalwire.com/signup)
 - Python and basic Python knowledge
 
 ---

--- a/docs/home/platform/basics/guides/technical-troubleshooting/creating-a-publically-exposed-webhook-and-configure-it-to-your-incoming-number/index.mdx
+++ b/docs/home/platform/basics/guides/technical-troubleshooting/creating-a-publically-exposed-webhook-and-configure-it-to-your-incoming-number/index.mdx
@@ -229,7 +229,7 @@ Conclusion
 Throughout this guide, you were introduced to a roadmap of turning your local backend application into a publically accessed webhook. 
 After creating a public URL, we were able to update a SignalWire number's SMS webhook so that we can carry out the instructions highlighted in our backend application.
 
-If you would like to test this example out, [create a SignalWire account and Space](https://id.signalwire.com/signup/account/new?s=1).
+If you would like to test this example out, [create a SignalWire account and Space](https://signalwire.com/signup).
 
 Please feel free to reach out to us on our [Community Slack](http://signalwire.community/) 
 or create a Support ticket if you need guidance!

--- a/docs/home/platform/dashboard/guides/changing-settings-in-your-signalwire-space/index.mdx
+++ b/docs/home/platform/dashboard/guides/changing-settings-in-your-signalwire-space/index.mdx
@@ -15,7 +15,7 @@ However, if you must change a SignalWire Space URL, please create a new Space on
 SignalWire's Support Team will navigate through the process of releasing and/or transferring phone numbers from a previous Space and delete the old Space when the release/transfer is complete.
 
 Your Space Name is a friendly name that can be changed. 
-This is the name that will appear on your [Space's sign-in page](https://id.signalwire.com/spaces) to help your users identify the correct Space. 
+This is the name that will appear on your [Space's sign-in page](https://signalwire.com/signin) to help your users identify the correct Space. 
 To change it from your Dashboard, click on the profile icon in the upper right corner and choose **Settings**. 
 Choose a new Space name and click the Save button. 
 

--- a/docs/home/platform/integrations/crm/zoho-crm-click-to-call/index.mdx
+++ b/docs/home/platform/integrations/crm/zoho-crm-click-to-call/index.mdx
@@ -166,6 +166,6 @@ This guide is intended to be a step-by-step walkthrough for users of any skill/k
 
 ### Try it Yourself
 
-If you would like to test this example out, you can create a SignalWire account and Space [here](https://id.signalwire.com/signup/account/new).
+If you would like to test this example out, you can create a SignalWire account and Space [here](https://signalwire.com/signup).
 
 Please feel free to reach out to us on our [Community Slack](https://signalwire.community/) or create a Support ticket if you need guidance!

--- a/docs/home/platform/integrations/softphones/microsip-softphone/index.mdx
+++ b/docs/home/platform/integrations/softphones/microsip-softphone/index.mdx
@@ -148,6 +148,6 @@ You should now be able to handle inbound and outbound calling from your SIP endp
 
 ### Try it Yourself
 
-If you would like to test this example out, [create a SignalWire account and Space](https://id.signalwire.com/signup/account/new).
+If you would like to test this example out, [create a SignalWire account and Space](https://signalwire.com/signup).
 
 Please feel free to reach out to us on our [Community Slack](https://signalwire.community/) or create a Support ticket if you need guidance!

--- a/src/pages/page/tadhack-2024/index.mdx
+++ b/src/pages/page/tadhack-2024/index.mdx
@@ -54,7 +54,7 @@ Before following the below steps, please complete the following prerequisites:
 
   - Install [Docker Desktop](https://www.docker.com/products/docker-desktop/)
   - Create a free [ngrok account](https://ngrok.com/)
-  - Sign up for a free [SignalWire Space](https://id.signalwire.com/onboarding)
+  - Sign up for a free [SignalWire Space](https://signalwire.com/signup)
 
 The script we run in step 3 will ask for your 
 SignalWire Space ID, 


### PR DESCRIPTION
…or in a few cases, `signalwire.com/signin`

This is for SEO/tracking reasons