### PR TITLE
Remove link from AI Get Started header

### DIFF
--- a/docs/home/products/ai/get-started/index.mdx
+++ b/docs/home/products/ai/get-started/index.mdx
@@ -6,9 +6,7 @@ title: Get Started with AI on the SignalWire Platform
 description: Deploy a serverless AI Agent and call it over the PSTN in under 5 minutes - for free
 ---
 
-import Frame from "@site/src/components/Extras/Frame/Frame";
 import Admonition from '@theme/Admonition';
-import { Card, CardGroup } from "@site/src/components/Extras/Card";
 import { LiaBookSolid, LiaCodeSolid, LiaCogsSolid, LiaPhoneSolid } from "react-icons/lia";
 
 # Create your first phone AI Agent
@@ -27,7 +25,7 @@ Initialize your agent in the Dashboard without code, assign a phone number, and 
 
 <Steps>
 
-### Sign up for a <a href="https://signalwire.com/signup" target="_blank">new SignalWire account</a>
+### Sign up for a new SignalWire account
 
 To begin, sign up for a SignalWire account. If you already have an account, log in.
 

--- a/docs/home/products/ai/index.mdx
+++ b/docs/home/products/ai/index.mdx
@@ -5,9 +5,6 @@ sidebar_position: 0
 title: SignalWire AI
 ---
 
-import Subtitle from '@site/src/components/typography/Subtitle'
-import { Card, CardGroup } from "@site/src/components/Extras/Card";
-import Frame from "@site/src/components/Extras/Frame/Frame"
 import { MdCode, MdSmartToy, MdAccountTree } from "react-icons/md";
 import UseCases from "./_usecases/_useCases.mdx";
 


### PR DESCRIPTION
# Documentation Update Pull Request

## Description

Remove link from AI Get Started header. The link was highlighting in an unintended/undesired way in the TOC.

[Updated the wiki](https://github.com/signalwire/docs/wiki/Written-Style-Guide#no-links-in-headers) with this new rule.

## Type of Change

- [x] New documentation
- [ ] Update to existing documentation

### Documentation Change Details
- remove link from header
- remove a few unnecessary component imports

## Checklist:

- [x] My documentation follows the [style guidelines](https://github.com/signalwire/signalwire-docs/wiki/Style-Guidelines) of this project
- [x] I have performed a self-review of my documentation
- [x] My changes generate no new warnings
- [x] Builds successfully locally
