### PR TITLE
Fix "Handling Calls from Code" instructions

### DIFF
--- a/docs/compatibility-api/guides/voice/general/handling-calls-from-code/index.mdx
+++ b/docs/compatibility-api/guides/voice/general/handling-calls-from-code/index.mdx
@@ -13,16 +13,15 @@ x-custom:
 
 # Handling Calls from Code
 
-In [Making and Receiving Phone Calls](/voice/getting-started/making-and-receiving-phone-calls) we
-learned how to use Compatibility XML bins to control outbound and inbound calls. In
-particular, we showed how to play a simple audio message.
+In [Making and Receiving Phone Calls](/voice/getting-started/making-and-receiving-phone-calls) 
+we learned how to use Compatibility XML bins to control outbound and inbound calls. 
+In particular, we showed how to play a simple audio message.
 
-Handling calls from code gives us more flexibility. Instead of serving a
-static XML bin, we can use a custom web server to decide the content of the XML
+Handling calls from code gives us more flexibility. 
+Instead of serving a static XML bin, we can use a custom web server to decide the content of the XML
 depending on the state of the call, on the caller, on the time, etc.
 
-In this guide, we will show how to create a simple phone service which will tell
-the user the current day, with a variation on weekends.
+In this guide, we will show how to create a simple phone service which will tell the user the current day, with a variation on weekends.
 
 ## Setting up the environment
 
@@ -203,15 +202,14 @@ app.listen(8080);
 
 </Tabs>
 
-In the next section we will configure a phone number so that, when it receives a
-message, SignalWire makes an HTTP request to our message handler endpoint. The
-HTTP request will contain as parameters values such as the source number or the
-body of the incoming message.
+In the next section we will configure a phone number to make an HTTP request to our call handler endpoint
+when an incoming call is received.
+The HTTP request will contain parameters including values such as the source number or the body of the incoming message.
 
-For our simple subscription service demo, our message handler needs to look at
-the body of the message to determine whether it contains the word "START" or
-"STOP". Depending on the word, we will emit an XML document which will produce
-different messages.
+For our simple phone service demo, our call handler needs to reference the current date and time,
+as well as the phone number of the caller.
+Our call handler will emit a modified cXML document based on those values, 
+allowing our application to modify the call flow and content based on server logic.
 
 <Tabs groupId="compatibility-api">
 


### PR DESCRIPTION
# Documentation Update Pull Request

## Description

Update paragraphs that incorrectly refer to a messaging demo with correct code description and instructions.

Related issue: #86 

## Type of Change

- [ ] New documentation
- [x] Update to existing documentation

## Checklist:

- [x] My documentation follows the [style guidelines](https://github.com/signalwire/signalwire-docs/wiki/Style-Guidelines) of this project
- [x] I have performed a self-review of my documentation
- [x] My changes generate no new warnings
- [x] Builds successfully locally