### PR TITLE
Fix the `Card` component to use the Docusaurus `Link` component

### DIFF
--- a/src/components/Blog/ReleaseCard/index.tsx
+++ b/src/components/Blog/ReleaseCard/index.tsx
@@ -59,3 +59,6 @@ export default function ReleaseCard({ library, version, releaseType }: ReleaseCa
     </div>
   );
 }
+
+
+

--- a/src/components/Extras/Card/Card.tsx
+++ b/src/components/Extras/Card/Card.tsx
@@ -1,4 +1,5 @@
 import React, { ComponentPropsWithoutRef, ElementType, ReactNode, Ref } from "react";
+import Link from "@docusaurus/Link";
 import styles from "./Card.module.css";
 import clsx from "clsx";
 import { CardImage } from "./CardImage";
@@ -57,7 +58,7 @@ export function Card<T extends ElementType = "div">({
   titleIcon,
   ...props
 }: CardProps<T>) {
-  const Component = as || props.href != undefined ? "a" : "div";
+  const Component = as || props.href != undefined ? Link : "div";
   const isImageSrc: boolean = typeof icon === "string";
 
   const renderIcon: JSX.Element = (

--- a/src/pages/internal/extras/Card.mdx
+++ b/src/pages/internal/extras/Card.mdx
@@ -259,7 +259,7 @@ High-performance realtime and compatible APIs
 </Card>
 <Card 
     title="Messaging" 
-    href="/sms"
+    href="/messaging"
     icon="/landing-assets/images/svg/ico-sms.svg"
 >
 High-throughput, compliant, programmable SMS and MMS
@@ -287,14 +287,14 @@ Send and receive faxes
 </Card>
 <Card 
     title="SWML" 
-    href="/sdks/reference/swml/introduction"
+    href="/swml"
     icon="/landing-assets/images/svg/ico-swml.svg"
 >
 Low-code, server-optional application builder
 </Card>
 <Card 
     title="AI" 
-    href="/sdks/reference/swml/methods/ai/"
+    href="/swml/guides/ai"
     icon="/landing-assets/images/svg/ico-ai.svg"
 >
 Incorporate AI functionality in minutes


### PR DESCRIPTION
# Other Changes Pull Request

## Description

The `Card` component was treating all links as simple anchor `<a>` links, thus not leveraging the React Router's fast SPA-like routing, and always falling back to the slower browser routing. 

This PR fixes that.

## Related Issue

Link to the issue here: [Issue #](

## Type of Change

- [ ] Docusaurus update/maintenance
    - [ ] Dependency update
    - [ ] Configuration change
    - [ ] Plugin update
    - [ ] Bug fix
    - [ ] Style Change
- [x] Performance improvement
- [ ] Refactoring
- [ ] Build process update
- [ ] Other (please specify):

<!-- If you selected "Docusaurus update/maintenance", please fill out the following section -->
### Docusaurus Update/Maintenance Details
- **Dependency Update**: Name and version of the updated dependency
- **Configuration Changed**: Describe the configuration changes made
- **Plugin Update**: Name and version of the updated plugin
- **Bug Fix**: Describe the bug that was fixed and the solution
- **Style Change**: Describe the style changes implemented 

### Other Change Details (if applicable)
- **Description**: Provide a detailed description of the change

## Motivation and Context

Less jarring and more SPA-like transitions where possible when clicking `Card`s that are linked to internal docs.

## Checklist:

- [x] My changes follow the [style guidelines](https://github.com/signalwire/signalwire-docs/wiki/Style-Guidelines) of this project
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings
- [x] Builds successfully locally 

## Additional Notes

Add any other context about the pull request here.
