### PR TITLE
Add script to allow people to easily modify spec files.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "@docusaurus/tsconfig": "^3.6.3",
         "@docusaurus/types": "^3.6.3",
         "@types/gtag.js": "^0.0.20",
+        "@types/node": "^22.13.10",
         "@types/react": "^18.3.14",
         "@types/react-slick": "^0.23.13",
         "docusaurus-plugin-markdown-printer": "./plugins/markdown-printer",
@@ -772,12 +773,12 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.0.tgz",
-      "integrity": "sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.10.tgz",
+      "integrity": "sha512-UPYc3SauzZ3JGgj87GgZ89JVdC5dj0AoetR5Bw6wj4niittNyFh6+eOGonYvJ1ao6B8lEa3Q3klS7ADZ53bc5g==",
       "dependencies": {
-        "@babel/template": "^7.25.9",
-        "@babel/types": "^7.26.0"
+        "@babel/template": "^7.26.9",
+        "@babel/types": "^7.26.10"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -862,11 +863,11 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.3.tgz",
-      "integrity": "sha512-WJ/CvmY8Mea8iDXo6a7RK2wbmJITT5fN3BEkRuFlxVyNx8jOKIIhmC4fSkTcPcf8JyavbBwIe6OpiCOBXt/IcA==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.10.tgz",
+      "integrity": "sha512-6aQR2zGE/QFi8JpDLjUZEPYOs7+mhKXm86VaKFiLP35JQwQb6bwUE+XbvkH0EptsYhbNBSUGaUBLKqxH1xSgsA==",
       "dependencies": {
-        "@babel/types": "^7.26.3"
+        "@babel/types": "^7.26.10"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -2040,9 +2041,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
-      "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.10.tgz",
+      "integrity": "sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -2051,9 +2052,9 @@
       }
     },
     "node_modules/@babel/runtime-corejs3": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.26.0.tgz",
-      "integrity": "sha512-YXHu5lN8kJCb1LOb9PgV6pvak43X2h4HvRApcN5SdWeaItQOzfn1hgP6jasD6KWQyJDBxrVmA9o9OivlnNJK/w==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.26.10.tgz",
+      "integrity": "sha512-uITFQYO68pMEYR46AHgQoyBg7KPPJDAbGn4jUTIRgCFJIp88MIBUianVOplhZDEec07bp9zIyr4Kp0FCyQzmWg==",
       "dependencies": {
         "core-js-pure": "^3.30.2",
         "regenerator-runtime": "^0.14.0"
@@ -2063,13 +2064,13 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.9.tgz",
-      "integrity": "sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==",
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.26.9.tgz",
+      "integrity": "sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==",
       "dependencies": {
-        "@babel/code-frame": "^7.25.9",
-        "@babel/parser": "^7.25.9",
-        "@babel/types": "^7.25.9"
+        "@babel/code-frame": "^7.26.2",
+        "@babel/parser": "^7.26.9",
+        "@babel/types": "^7.26.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2093,9 +2094,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.3",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.3.tgz",
-      "integrity": "sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.10.tgz",
+      "integrity": "sha512-emqcG3vHrpxUKTrxcblR36dcrcoRDvKmnL/dCL6ZsHaShW80qxCAcNhzQZrpeM765VzEos+xOi4s+r4IXzTwdQ==",
       "dependencies": {
         "@babel/helper-string-parser": "^7.25.9",
         "@babel/helper-validator-identifier": "^7.25.9"
@@ -6636,9 +6637,9 @@
       "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
     },
     "node_modules/@types/node": {
-      "version": "22.10.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.2.tgz",
-      "integrity": "sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==",
+      "version": "22.13.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
+      "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -7645,9 +7646,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -20259,9 +20260,9 @@
       }
     },
     "node_modules/prismjs": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
-      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
       "engines": {
         "node": ">=6"
       }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "build:remark-plugin-api-table": "cd plugins/remark-plugin-api-table && npm run build && cd ../../",
     "build:plugins": "npm run build:remark-plugin-yaml-and-json && npm run build:docusaurus-plugin-showcase && npm run build:remark-plugin-a11y-checker && npm run build:remark-plugin-vfile-reporter && npm run build:remark-plugin-image-to-figure && npm run build:remark-plugin-api-table",
     "build:datasphere-api": "cd ./api/signalwire-rest/datasphere-api && tsp compile . && cd ../../../../",
-    "build:fabric-api": "cd ./api/signalwire-rest/fabric-api && tsp compile . && cd ../../../../"
+    "build:fabric-api": "cd ./api/signalwire-rest/fabric-api && tsp compile . && cd ../../../../",
+    "build:modify-server-urls": "npx ts-node scripts/update-server-urls.ts"
   },
   "dependencies": {
     "@docusaurus/core": "^3.6.3",
@@ -47,11 +48,11 @@
     "@typespec/openapi3": "0.64.0",
     "@typespec/rest": "0.64.1",
     "clsx": "^2.1.1",
-    "dompurify": "^3.2.4",
     "docusaurus-plugin-openapi-docs": "^4.2.0",
     "docusaurus-plugin-sass": "0.2.6",
     "docusaurus-theme-openapi-docs": "^4.2.0",
     "docusaurus-theme-search-typesense": "^0.22.0",
+    "dompurify": "^3.2.4",
     "dotenv": "^16.4.5",
     "plugin-image-zoom": "github:flexanalytics/plugin-image-zoom",
     "prism-react-renderer": "^2.3.1",
@@ -77,14 +78,15 @@
     ]
   },
   "devDependencies": {
-    "docusaurus-plugin-showcase": "./plugins/docusaurus-plugin-showcase",
-    "docusaurus-plugin-markdown-printer": "./plugins/markdown-printer",
     "@docusaurus/module-type-aliases": "^3.6.3",
     "@docusaurus/tsconfig": "^3.6.3",
     "@docusaurus/types": "^3.6.3",
     "@types/gtag.js": "^0.0.20",
+    "@types/node": "^22.13.10",
     "@types/react": "^18.3.14",
     "@types/react-slick": "^0.23.13",
+    "docusaurus-plugin-markdown-printer": "./plugins/markdown-printer",
+    "docusaurus-plugin-showcase": "./plugins/docusaurus-plugin-showcase",
     "linkinator": "^5.0.2",
     "prettier": "^3.3.3",
     "sharp": "^0.33.4",

--- a/scripts/update-server-urls.ts
+++ b/scripts/update-server-urls.ts
@@ -1,0 +1,178 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { parse, stringify } from 'yaml';
+
+// Use require for the plugin config to avoid TypeScript trying to compile it
+const { openapiPlugin } = require('../config/pluginsConfig/docusaurus-plugin-openapi-docs');
+
+interface ServerVariable {
+  default?: string;
+  enum?: string[];
+  description?: string;
+}
+
+interface ServerConfig {
+  url: string;
+  description?: string;
+  variables?: Record<string, ServerVariable>;
+}
+
+interface OpenAPISpec {
+  servers?: ServerConfig[];
+  // ... other OpenAPI fields
+}
+
+interface VariableConfig {
+  default?: string;
+  varName?: string;  // New variable name to replace the old one
+}
+
+interface ServerUrlConfig {
+  urlPattern: string;
+  replacement: string;
+  variables?: Record<string, VariableConfig | null>;
+}
+
+interface ApiConfig {
+  specPath: string;
+  outputDir: string;
+  sidebarOptions: {
+    categoryLinkSource: string;
+    groupPathsBy: string;
+  };
+}
+
+function escapeRegExp(string: string): string {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function createUrlPattern(pattern: string): RegExp {
+  // Escape special characters except for curly braces and their contents
+  const parts = pattern.split(/(\{[^}]+\})/);
+  const escapedParts = parts.map((part, index) => {
+    // If it's a variable (wrapped in curly braces), keep it as is
+    if (part.startsWith('{') && part.endsWith('}')) {
+      return part;
+    }
+    // Otherwise escape special characters
+    return escapeRegExp(part);
+  });
+  return new RegExp(escapedParts.join(''));
+}
+
+function updateServerUrls(specPath: string, config: ServerUrlConfig): void {
+  try {
+    // Read and parse the YAML file
+    const fileContent = fs.readFileSync(specPath, 'utf8');
+    const spec = parse(fileContent) as OpenAPISpec;
+
+    if (!spec.servers || !Array.isArray(spec.servers)) {
+      console.warn(`No servers found in spec: ${specPath}`);
+      return;
+    }
+
+    // Update each server configuration
+    spec.servers = spec.servers.map(server => {
+      // Update the URL using regex
+      const pattern = createUrlPattern(config.urlPattern);
+      server.url = server.url.replace(pattern, config.replacement);
+
+      // Handle variables if they exist
+      if (config.variables && server.variables) {
+        const updatedVariables: Record<string, ServerVariable> = {};
+
+        // Process each variable in the config
+        Object.entries(config.variables).forEach(([oldVarName, varConfig]) => {
+          if (varConfig === null) {
+            // Skip this variable (effectively removing it)
+            return;
+          }
+
+          const currentVar = server.variables?.[oldVarName];
+          if (currentVar) {
+            // Create updated variable with new name if specified
+            const newVarName = varConfig.varName || oldVarName;
+            updatedVariables[newVarName] = {
+              ...currentVar,
+              // Update default if specified
+              ...(varConfig.default !== undefined && { default: varConfig.default })
+            };
+          }
+        });
+
+        // Replace the variables object with our updated version
+        server.variables = updatedVariables;
+      }
+
+      return server;
+    });
+
+    // Write the updated spec back to file
+    const updatedYaml = stringify(spec);
+    fs.writeFileSync(specPath, updatedYaml, 'utf8');
+    console.log(`Updated server URLs in: ${specPath}`);
+  } catch (error) {
+    console.error(`Error processing ${specPath}:`, error);
+  }
+}
+
+function processSpecs(config: ServerUrlConfig): void {
+  // Extract spec paths from the OpenAPI plugin config
+  if (!openapiPlugin || !Array.isArray(openapiPlugin) || !openapiPlugin[1]?.config) {
+    console.error('Invalid OpenAPI plugin configuration');
+    return;
+  }
+
+  const pluginConfig = openapiPlugin[1].config as Record<string, ApiConfig>;
+  const pattern = createUrlPattern(config.urlPattern);
+  
+  Object.values(pluginConfig).forEach(apiConfig => {
+    const specPath = path.resolve(process.cwd(), apiConfig.specPath);
+    
+    try {
+      // Parse the YAML to check server URLs and variables specifically
+      const content = fs.readFileSync(specPath, 'utf8');
+      const spec = parse(content) as OpenAPISpec;
+
+      // Check if any server URL matches our pattern or if there are variables to update
+      const hasMatchingUrl = spec.servers?.some(server => pattern.test(server.url)) ?? false;
+      const hasMatchingVariables = spec.servers?.some(server => {
+        if (!server.variables || !config.variables) return false;
+        // Check if any of the variables we want to update exist in this server
+        return Object.keys(config.variables).some(varName => varName in server.variables!);
+      }) ?? false;
+      
+      if (hasMatchingUrl || hasMatchingVariables) {
+        console.log(`Processing spec: ${specPath}`);
+        if (hasMatchingUrl) {
+          console.log('  - Found matching URL pattern');
+        }
+        if (hasMatchingVariables) {
+          console.log('  - Found matching variables to update');
+        }
+        updateServerUrls(specPath, config);
+      } else {
+        console.log(`Skipping spec (no matching URLs or variables): ${specPath}`);
+      }
+    } catch (error) {
+      console.error(`Error reading spec file ${specPath}:`, error);
+    }
+  });
+}
+
+// Configuration that will be applied to all matching specs
+const varName = 'project_name';  // New variable name
+
+const config: ServerUrlConfig = {
+  urlPattern: 'https://{space_name}.signalwire.com/',
+  replacement: `https://{${varName}}.new.yes.com/`,
+  variables: {
+    // Set to null to remove the variable completely
+    space_name: {
+      default: '{NEW_NAME}', // replace with your new default value
+      varName: varName  // This will rename space_name to project_name
+    }
+  }
+};
+
+processSpecs(config);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "strict": true,
     "skipLibCheck": true,
     "importsNotUsedAsValues": "remove",
-    "types": ["jest", "@types/react"],
+    "types": ["jest", "@types/react", "node"],
     "jsx": "react",
     "paths": {
       "@site/*": ["../*"],


### PR DESCRIPTION
# Other Changes Pull Request

## Description

Temporary solution to allow users to easily edit our rest specs through a script/config. Allows people to conform our endpoints to theirs.


## Related Issue

Link to the issue here: Issue #72 

## Type of Change

- [ ] Docusaurus update/maintenance
    - [ ] Dependency update
    - [ ] Configuration change
    - [ ] Plugin update
    - [ ] Bug fix
    - [ ] Style Change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Build process update
- [x] Other (please specify):



## Motivation and Context

To help users looking to white label docs.

## Checklist:

- [x] My changes follow the [style guidelines](https://github.com/signalwire/signalwire-docs/wiki/Style-Guidelines) of this project
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings
- [x] Builds successfully locally 