### PR TITLE
Fix Typesense error during development

### DIFF
--- a/config/typesense.ts
+++ b/config/typesense.ts
@@ -7,11 +7,15 @@
  * Typesense technical reference: https://typesense.org/docs/0.24.0/api/search.html#search-parameters
  */
 
-import type { ThemeConfig } from 'docusaurus-theme-search-typesense';
-import type { ConfigurationOptions } from 'typesense/lib/Typesense/Configuration';
-import type { SearchParams } from 'typesense/lib/Typesense/Documents';
+import dotenv from "dotenv";
+import type { ThemeConfig } from "docusaurus-theme-search-typesense";
+import type { ConfigurationOptions } from "typesense/lib/Typesense/Configuration";
+import type { SearchParams } from "typesense/lib/Typesense/Documents";
 
-const config: NonNullable<ThemeConfig['typesense']> = {
+// Load environment variables
+dotenv.config();
+
+const config: NonNullable<ThemeConfig["typesense"]> = {
   typesenseCollectionName: process.env.TYPESENSE_COLLECTION_NAME ?? "placeholder",
 
   typesenseServerConfig: {
@@ -31,4 +35,4 @@ const config: NonNullable<ThemeConfig['typesense']> = {
   searchPagePath: false,
 };
 
-export default config; 
+export default config;


### PR DESCRIPTION
# Other Changes Pull Request

## Description

During development (`npm run start`) typespec wasn't able to access the environment variables. Fixed that.

## Type of Change

- [ ] Docusaurus update/maintenance
    - [ ] Dependency update
    - [ ] Configuration change
    - [ ] Plugin update
    - [x] Bug fix
    - [ ] Style Change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Build process update
- [ ] Other (please specify):

<!-- If you selected "Docusaurus update/maintenance", please fill out the following section -->
### Docusaurus Update/Maintenance Details
- **Dependency Update**: Name and version of the updated dependency
- **Configuration Changed**: Describe the configuration changes made
- **Plugin Update**: Name and version of the updated plugin
- **Bug Fix**: `npm run start` has typesense erroring out because it wasn't able to access .env file
- **Style Change**: Describe the style changes implemented 

### Other Change Details (if applicable)
- **Description**: Provide a detailed description of the change

## Checklist:

- [x] My changes follow the [style guidelines](https://github.com/signalwire/signalwire-docs/wiki/Style-Guidelines) of this project
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings
- [x] Builds successfully locally 
