### PR TITLE
remove filter_username from sip endpoint spec

### DIFF
--- a/api/signalwire-rest/space-api/_spec_.yaml
+++ b/api/signalwire-rest/space-api/_spec_.yaml
@@ -7011,14 +7011,6 @@ paths:
       tags:
         - SIP Endpoints
       parameters:
-        - name: filter_username
-          in: query
-          description: >-
-            String representing the username portion of the endpoint. Will
-            return all SIP Endpoints containing this value as a substring.
-          required: false
-          schema:
-            type: string
         - name: filter_caller_id
           in: query
           description: >-


### PR DESCRIPTION
remove filter_username from legacy sip endpoint spec