### PR TITLE
SIP endpoint - remove filter_caller_id

### DIFF
--- a/api/signalwire-rest/space-api/_spec_.yaml
+++ b/api/signalwire-rest/space-api/_spec_.yaml
@@ -7010,16 +7010,7 @@ paths:
         The API token must include the following scopes: _Voice_.
       tags:
         - SIP Endpoints
-      parameters:
-        - name: filter_caller_id
-          in: query
-          description: >-
-            Friendly Caller ID used as the `CNAM` when dialing a phone number or
-            the `From` when dialing another SIP Endpoint. Will return all SIP
-            Endpoints containing this value as a substring.
-          required: false
-          schema:
-            type: string
+      parameters: []
       responses:
         '200':
           description: OK

--- a/api/signalwire-rest/space-api/_spec_.yaml
+++ b/api/signalwire-rest/space-api/_spec_.yaml
@@ -6998,6 +6998,7 @@ paths:
                         example: John Smith
   /endpoints/sip:
     get:
+      deprecated: true
       operationId: list_sip_endpoints
       summary: List all SIP Endpoints.
       description: |
@@ -7008,9 +7009,13 @@ paths:
 
         #### Permissions
         The API token must include the following scopes: _Voice_.
+
+        :::important
+        This endpoint is deprecated. Use the [SIP Endpoints API](/rest/signalwire-rest/endpoints/fabric/sip-endpoints) instead.
+        :::
+
       tags:
         - SIP Endpoints
-      parameters: []
       responses:
         '200':
           description: OK
@@ -7278,6 +7283,7 @@ paths:
                               example: >-
                                 https://dev.signalwire.com/relay-bins/f9d13f68-f71e-4042-95bb-b07b9e2f2f92
     post:
+      deprecated: true
       operationId: create_sip_endpoint
       summary: Create a SIP Endpoint
       description: |
@@ -7286,6 +7292,10 @@ paths:
 
         #### Permissions
         The API token must include the following scopes: _Voice_.
+
+        :::important
+        This endpoint is deprecated. Use the [SIP Endpoints API](/rest/signalwire-rest/endpoints/fabric/sip-endpoints) instead.
+        :::
       tags:
         - SIP Endpoints
       requestBody:
@@ -7772,6 +7782,7 @@ paths:
                           https://dev.signalwire.com/relay-bins/f9d13f68-f71e-4042-95bb-b07b9e2f2f92
   /endpoints/sip/{id}:
     get:
+      deprecated: true
       operationId: retrieve_sip_endpoint
       summary: Retrieve a SIP Endpoint
       description: |
@@ -7781,6 +7792,10 @@ paths:
 
         #### Permissions
         The API token must include the following scopes: _Voice_.
+
+        :::important
+        This endpoint is deprecated. Use the [SIP Endpoints API](/rest/signalwire-rest/endpoints/fabric/sip-endpoints) instead.
+        :::
       tags:
         - SIP Endpoints
       parameters:
@@ -8030,6 +8045,7 @@ paths:
                         example: >-
                           https://dev.signalwire.com/relay-bins/f9d13f68-f71e-4042-95bb-b07b9e2f2f92
     put:
+      deprecated: true
       operationId: update_sip_endpoint
       summary: Update a SIP Endpoint
       description: |
@@ -8038,6 +8054,10 @@ paths:
 
         #### Permissions
         The API token must include the following scopes: _Voice_.
+
+        :::important
+        This endpoint is deprecated. Use the [SIP Endpoints API](/rest/signalwire-rest/endpoints/fabric/sip-endpoints) instead.
+        :::
       tags:
         - SIP Endpoints
       parameters:
@@ -8527,6 +8547,7 @@ paths:
                         example: >-
                           https://dev.signalwire.com/relay-bins/f9d13f68-f71e-4042-95bb-b07b9e2f2f92
     delete:
+      deprecated: true
       operationId: delete_sip_endpoint
       summary: Delete a SIP Endpoint
       description: |
@@ -8536,6 +8557,10 @@ paths:
 
         #### Permissions
         The API token must include the following scopes: _Voice_.
+
+        :::important
+        This endpoint is deprecated. Use the [SIP Endpoints API](/rest/signalwire-rest/endpoints/fabric/sip-endpoints) instead.
+        :::
       tags:
         - SIP Endpoints
       parameters:


### PR DESCRIPTION
remove `filter_caller_id` query param from spec.


marked endpoints as deprecated

added links to new endpoints.