### PR TITLE
Correct Conference category description on Log intro page

### DIFF
--- a/docs/home/platform/dashboard/logs/index.mdx
+++ b/docs/home/platform/dashboard/logs/index.mdx
@@ -19,7 +19,7 @@ To get to your logs, you will need to navigate to the **Logs** tab in the left-h
 ## Export logs
 
 Once you are in the Logs tab, you will see a list of all the logs that have been generated in your Space.
-They will be separated into different categories in the sidebar, such as **Conferencing** (which encompasses **Voice** and **Video** logs), **Messaging**, and **Fax** logs.
+They will be separated into different categories in the sidebar, such as **Conferencing**, **Messaging**, and **Fax** logs.
 
 Additionally, you can filter the logs by **IDs**, **Date Ranges** or **Specific Dates** by clicking the filter icon in the top right corner.
 


### PR DESCRIPTION
# Documentation Update Pull Request

## Description

I'd updated the Dashboard->Log page to imply Conference included both voice and video. (last PR: https://github.com/signalwire/docs/pull/225)

But in reality, clicking on the "Logs" sidebar button will take you to Voice logs. Clicking on the "Conference" sub-button will take you to video conference logs 😕 

## Type of Change

- [ ] New documentation
- [x] Update to existing documentation

### Documentation Change Details
- **Changes Summary**: Small change, conference means conference now

## Motivation and Context

Why is this change required? What problem does it solve?

## Checklist:

- [x] My documentation follows the [style guidelines](https://github.com/signalwire/signalwire-docs/wiki/Style-Guidelines) of this project
- [x] I have performed a self-review of my documentation
- [x] My changes generate no new warnings
- [x] Builds successfully locally

## Additional Notes

Add any other context about the documentation update here.
