### PR TITLE
Redirect for broken ai agent dashboard link

### DIFF
--- a/provisioning/nginx/redirects.map
+++ b/provisioning/nginx/redirects.map
@@ -47,3 +47,7 @@
 # Redirect for cXML applications since rest endpoints were removed - 4/18/25
 /compatibility-api/guides/general/creating-and-using-cxml-applications /compatibility-api/guides/general/creating-and-using-cxml-scripts;
 /compatibility-api/guides/general/creating-and-using-cxml-applications/ /compatibility-api/guides/general/creating-and-using-cxml-scripts;
+
+# Noticed a broken link from AI Agent dashboard UI on 4/30/25
+/guides/voice-and-languages/ /voice/getting-started/voice-and-languages;
+/guides/voice-and-languages /voice/getting-started/voice-and-languages;


### PR DESCRIPTION
Adds the following lines to redirects.map:

```yaml
/guides/voice-and-languages/ /voice/getting-started/voice-and-languages;
/guides/voice-and-languages /voice/getting-started/voice-and-languages;
```

This broken link (https://developer.signalwire.com/guides/voice-and-languages/) was found at this location in the Dashboard:

AI Agents > Create > Edit > Languages > Voice > tooltip