### PR TITLE
Add Eng-Prime-Review GHA Workflow - 14018

### DIFF
--- a/.github/workflows/assign_reviewers_from_team.yml
+++ b/.github/workflows/assign_reviewers_from_team.yml
@@ -1,0 +1,68 @@
+name: Convert Team Review to Individual Assignments
+
+on:
+  pull_request:
+    types: [ review_requested ]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  assign_reviewers_from_team:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.requested_team.name == 'eng-prime-review'}}
+    env:
+      GH_TOKEN: ${{ secrets.PRIME_REVIEW_GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
+      PR_NUMBER: ${{ github.event.number }}
+    steps:
+      - run: echo "A review was requested from eng-prime-review"
+
+      - name: Get usernames for all members in the requested team excluding the PR author
+        id: get-members
+        run: |
+          PR_AUTHOR="${{ github.event.pull_request.user.login }}"
+
+          echo "Retrieving all members in eng-prime-review.."
+          MEMBERS=$(curl -L \
+             -H "Accept: application/vnd.github+json" \
+             -H "Authorization: Bearer $GH_TOKEN" \
+             -H "X-GitHub-Api-Version: 2022-11-28" \
+             https://api.github.com/orgs/signalwire/teams/eng-prime-review/members)
+
+          echo "Extracting usernames from response and filtering out PR author from list.."
+          MEMBER_USERNAMES=$(echo $MEMBERS | jq -c '[.[] | .login | select(. != "'$PR_AUTHOR'")]')
+
+          echo "members=$MEMBER_USERNAMES" >> $GITHUB_ENV
+
+      - name: Assign each team member for review
+        run: |
+          source $GITHUB_ENV
+          PAYLOAD=$(jq -n --argjson reviewers "$members" '{"reviewers": $reviewers}')
+
+          echo "Assigning each member in eng-prime-review as a reviewer.."
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/$REPO/pulls/$PR_NUMBER/requested_reviewers \
+            -d "$PAYLOAD"
+
+      - name: Remove Team Review Request
+        run: |
+          source $GITHUB_ENV
+          PAYLOAD=$(jq -n --argjson reviewers '[]' --argjson team_reviewers '["eng-prime-review"]' '{"reviewers": $reviewers, "team_reviewers": $team_reviewers}')
+          echo $PAYLOAD
+
+          echo "Removing review request for team eng-prime-review.."
+          curl -L \
+            -X DELETE \
+            -H "Accept: application/vnd.github+json" \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/$REPO/pulls/$PR_NUMBER/requested_reviewers \
+            -d "$PAYLOAD"


### PR DESCRIPTION
# Other Changes Pull Request

## Description

When `@eng-prime-reviewers` is added as a team reviewer on a prime-rails PR, our github workflow uses the team assignment to individually add each team member as a reviewer, and then removes the team tag. 

This is because with a team tag, any approving review is enough to take away the team tag, and only that person remains as the reviewer. Ideally, we'd like every team member to have the opportunity to review pull requests, even if it's after they are merged. 

`.github/workflows/assign_reviewers_from_team.yml`

## Related Issue

Link to the issue here: [Issue #14018](https://github.com/signalwire/cloud-product/issues/14018)

## Type of Change

- [ ] Docusaurus update/maintenance
    - [ ] Dependency update
    - [ ] Configuration change
    - [ ] Plugin update
    - [ ] Bug fix
    - [ ] Style Change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Build process update
- [x] Other (please specify): GHA Workflow Addition

### Other Change Details (if applicable)
This adds the described workflow to the `docs` repo. 

## Motivation and Context
prime-rails is only one of our repos, and this workflow would be helpful in any repo that we frequently work in. We can safely add this to any repo without causing problems for other teams, as the workflow is only triggered when `@eng-prime-review` is tagged. 

## Checklist:
- [x] My changes follow the [style guidelines](https://github.com/signalwire/signalwire-docs/wiki/Style-Guidelines) of this project
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings
- [x] Builds successfully locally 

## Additional Notes
N/A
