### PR TITLE
slug fix

### DIFF
--- a/api/signalwire-rest/fabric-api/_spec_.yaml
+++ b/api/signalwire-rest/fabric-api/_spec_.yaml
@@ -7256,7 +7256,7 @@ paths:
       tags:
         - SWML Applications
       summary: List SWML Applications
-      operationId: listSWmlApplications
+      operationId: listSWMLApplications
       responses:
         '200':
           description: A list of SWML Applications

--- a/provisioning/nginx/redirects.map
+++ b/provisioning/nginx/redirects.map
@@ -1249,3 +1249,7 @@
 /rest/signalwire-rest/endpoints/fabric/external-swml-handlers-update/ /rest/signalwire-rest/endpoints/fabric/swml-webhooks-update;
 /rest/signalwire-rest/endpoints/fabric/external-swml-handlers-delete /rest/signalwire-rest/endpoints/fabric/swml-webhooks-delete;
 /rest/signalwire-rest/endpoints/fabric/external-swml-handlers-delete/ /rest/signalwire-rest/endpoints/fabric/swml-webhooks-delete;
+
+# REST API slug fix, 6/3/25
+/rest/signalwire-rest/endpoints/fabric/list-s-wml-applications /rest/signalwire-rest/endpoints/fabric/list-swml-applications;
+/rest/signalwire-rest/endpoints/fabric/list-s-wml-applications/ /rest/signalwire-rest/endpoints/fabric/list-swml-applications;


### PR DESCRIPTION
Related to #85 

Changed `operationId` so the slug was in proper format.