### PR TITLE
Remove Japan from international numbers

### DIFF
--- a/website/docs/main/home/platform/dashboard/administration/how-to-enable-international-outbound-dialing-sms/index.mdx
+++ b/website/docs/main/home/platform/dashboard/administration/how-to-enable-international-outbound-dialing-sms/index.mdx
@@ -20,7 +20,6 @@ SignalWire officially supports acquiring numbers in the following countries:
 - 🇦🇺 Australia
 - 🇨🇦 Canada
 - 🇮🇪 Ireland
-- 🇯🇵 Japan
 - 🇳🇿 New Zealand
 - 🇬🇧 United Kingdom
 - 🇺🇸 United States


### PR DESCRIPTION
# Documentation Update Pull Request

## Description

Remove Japan from supported numbers. 

<!-- Delete the `Related Issue` section if there is no related issue open with this Pull Request -->
## Related Issue

## Type of Change

- [ ] New documentation
- [x] Update to existing documentation

## Motivation and Context

We don't support japanese numbers anymore.

## Checklist:

- [x] My documentation follows the [style guidelines](https://github.com/signalwire/signalwire-docs/wiki/Style-Guidelines) of this project
- [x] I have performed a self-review of my documentation
- [x] My changes generate no new warnings
- [x] Builds successfully locally

## Additional Notes

Add any other context about the documentation update here.
