### PR TITLE
Add status callback fields to CXML and SWML Scripts endpoints

### DIFF
--- a/specs/signalwire-rest/fabric-api/_spec_.yaml
+++ b/specs/signalwire-rest/fabric-api/_spec_.yaml
@@ -7799,7 +7799,7 @@ paths:
                       type: string
                       format: date-time
                       example: '2024-01-02T00:00:00Z'
-                    laml_bin:
+                    cxml_script:
                       allOf:
                         - type: object
                           properties:
@@ -7857,6 +7857,14 @@ paths:
                       example: >-
                         <?xml version="1.0"
                         encoding="UTF-8"?><Response></Response>
+                    status_callback_url:
+                      type: string
+                      format: uri
+                      example: https://website.com/status
+                    status_callback_method:
+                      type: string
+                      enum: [GET, POST]
+                      example: GET
       responses:
         '200':
           description: A cXML Script
@@ -7887,7 +7895,7 @@ paths:
                     type: string
                     format: date-time
                     example: '2024-01-02T00:00:00Z'
-                  laml_bin:
+                  cxml_script:
                     allOf:
                       - type: object
                         properties:
@@ -7924,6 +7932,14 @@ paths:
                           display_name:
                             type: string
                             example: My cXML Script
+                          status_callback_url:
+                            type: string
+                            format: uri
+                            example: https://website.com/status
+                          status_callback_method:
+                            type: string
+                            enum: [GET, POST]
+                            example: GET
         '422':
           description: Unprocessable Entity
           content:
@@ -8000,7 +8016,7 @@ paths:
                     type: string
                     format: date-time
                     example: '2024-01-02T00:00:00Z'
-                  laml_bin:
+                  cxml_script:
                     allOf:
                       - type: object
                         properties:
@@ -8075,6 +8091,16 @@ paths:
                         sections:
                           main:
                             - play: say:Hello from SignalWire!
+                - type: object
+                  properties:
+                    status_callback_url:
+                      type: string
+                      format: uri
+                      example: https://website.com/status
+                    status_callback_method:
+                      type: string
+                      enum: [GET, POST]
+                      example: GET
       responses:
         '200':
           description: A cXML Script
@@ -8105,7 +8131,7 @@ paths:
                     type: string
                     format: date-time
                     example: '2024-01-02T00:00:00Z'
-                  laml_bin:
+                  cxml_script:
                     allOf:
                       - type: object
                         properties:
@@ -8144,6 +8170,14 @@ paths:
                           display_name:
                             type: string
                             example: My cXML Script
+                          status_callback_url:
+                            type: string
+                            format: uri
+                            example: https://website.com/status
+                          status_callback_method:
+                            type: string
+                            enum: [GET, POST]
+                            example: GET
         '422':
           description: Unprocessable Entity
           content:

--- a/specs/signalwire-rest/fabric-api/_spec_.yaml
+++ b/specs/signalwire-rest/fabric-api/_spec_.yaml
@@ -6908,6 +6908,14 @@ paths:
                             display_name:
                               type: string
                               example: Booking Assistant
+                            status_callback_url:
+                              type: string
+                              format: uri
+                              example: https://website.com/status
+                            status_callback_method:
+                              type: string
+                              enum: [POST]
+                              example: POST
     post:
       tags:
         - SWML Scripts
@@ -6932,6 +6940,10 @@ paths:
                         sections:
                           main:
                           - play: say:Hello from SignalWire!
+                    status_callback_url:
+                      type: string
+                      format: uri
+                      example: https://website.com/status
       responses:
         '200':
           description: A SWML Script
@@ -6994,6 +7006,14 @@ paths:
                           display_name:
                             type: string
                             example: Say Hello from SignalWire
+                          status_callback_url:
+                            type: string
+                            format: uri
+                            example: https://website.com/status
+                          status_callback_method:
+                            type: string
+                            enum: [POST]
+                            example: POST
         '422':
           description: Unprocessable Entity
           content:
@@ -7101,6 +7121,14 @@ paths:
                           display_name:
                             type: string
                             example: Booking Assistant
+                          status_callback_url:
+                            type: string
+                            format: uri
+                            example: https://website.com/status
+                          status_callback_method:
+                            type: string
+                            enum: [POST]
+                            example: POST
     put:
       tags:
         - SWML Scripts
@@ -7141,6 +7169,12 @@ paths:
                         sections:
                           main:
                             - play: say:Hello from SignalWire!
+                - type: object
+                  properties:
+                    status_callback_url:
+                      type: string
+                      format: uri
+                      example: https://website.com/status
       responses:
         '200':
           description: A SWML Script
@@ -7202,6 +7236,14 @@ paths:
                           display_name:
                             type: string
                             example: Booking Assistant
+                          status_callback_url:
+                            type: string
+                            format: uri
+                            example: https://website.com/status
+                          status_callback_method:
+                            type: string
+                            enum: [POST]
+                            example: POST
         '422':
           description: Unprocessable Entity
           content:


### PR DESCRIPTION
# REST API Update Pull Request

## Related Issue
https://github.com/signalwire/cloud-product/issues/15477
 https://github.com/signalwire/cloud-product/issues/15251


## Description

This PR adds status callback functionality to CXML Scripts and SWML Scripts endpoints in the Fabric API specification. The changes expose the ability to set status callback fields that were previously only
  available through the Fabric UI.

  CXML Scripts Changes:
  - Added status_callback_url and status_callback_method fields to POST and PUT request bodies
  - Updated response schemas to include both fields in the serialized response
  - Fields support both GET and POST methods for callbacks

  SWML Scripts Changes:
  - Added status_callback_url field to POST and PUT request bodies (method selection not exposed)
  - Updated all response schemas (GET list, GET single, POST, PUT) to include both status_callback_url and status_callback_method fields
  - status_callback_method is always set to "POST" for SWML Scripts (matches existing internal behavior)

## Type of Change

- [] New endpoint
- [x] Update to existing endpoint


## Checklist:

- [x] I have read and fully understand the [process for updating the REST API](https://github.com/signalwire/signalwire-docs/wiki/REST-API-Specs-&-Docs) 
- [] [Mandatory fields](https://github.com/signalwire/signalwire-docs/wiki/REST-API-Specs-&-Docs#documentation-required-decorators) are present in the TypeSpec files.
- [ ] TypeSpec files successfully compiled OpenAPI spec files.
  - [ ] No new warnings were generated during the compilation process. 
- [x] OpenAPI spec files were validated with a SWAGGER UI tool to ensure they are correct.
- [ ] The DevEx team has been alerted with the new changed by including the `team/developer-experience` label in the PR.



## Additional Notes

Add any other context about the pull request here.
