### PR TITLE
Update carrier fees

### DIFF
--- a/website/docs/main/home/messaging/sms/carrier-passthrough-fees/index.mdx
+++ b/website/docs/main/home/messaging/sms/carrier-passthrough-fees/index.mdx
@@ -52,9 +52,9 @@ numbers.
     | TextNow                                     | $0.0020       | $0           | United States |
     | Bluegrass                                   | $0.0025       | $0           | United States |
     | Claro Puerto Rico                           | $0.00875      | $0           | United States |
-    | Dish Wireless                               | $0.0035       | $0           | United States |
+    | Dish Wireless                               | $0.0035       | $0.0035      | United States |
     | Liberty Puerto Rico                         | $0.005175     | $0           | United States |
-    | 1stPoint, FirstPoint                        | $0.0035       | $0           | United States |
+    | 1stPoint, FirstPoint                        | $0.004        | $0.004       | United States |
     | ASTAC                                       | $0.0035       | $0.0035      | United States |
     | Break Away Wireless                         | $0.0035       | $0.0035      | United States |
     | Carolina West Wireless                      | $0.0035       | $0.0035      | United States |
@@ -257,12 +257,14 @@ Carriers assess the below fees for messages sent from short code numbers.
     | Cellcom                                     | $0.0035       | $0.0035      | United States |
     | CellularOne Northeast Arizona (C1NEAZ)      | $0.004        | $0           | United States |
     | Chat Mobility                               | $0.0035       | $0.0035      | United States |
+    | Cogeco                                      | $0.0035       | $0           | United States |
     | Commio                                      | $0.004        | $0           | United States |
     | Copper Valley Wireless                      | $0.0035       | $0.0035      | United States |
     | CTC (Cambridge Telephone Company)           | $0.0035       | $0.0035      | United States |
     | CTCI (Custer Tel)                           | $0.0035       | $0.0035      | United States |
     | Digital Communications Consulting (DCC)     | $0.004        | $0           | United States |
     | Enflick / TextNow                           | $0.004        | $0           | United States |
+    | Fastwyre                                    | $0.0035       | $0.0035      | United States |
     | GCI Wireless                                | $0.0035       | $0.0035      | United States |
     | Inland Cellular                             | $0.0035       | $0.0035      | United States |
     | Inteliquent                                 | $0.004        | $0           | United States |
@@ -274,6 +276,7 @@ Carriers assess the below fees for messages sent from short code numbers.
     | NNTC (Nucla-Naturita Tel)                   | $0.0035       | $0.0035      | United States |
     | Northwest Cell                              | $0.0035       | $0.0035      | United States |
     | NumberAccess                                | $0.004        | $0           | United States |
+    | Optimera                                    | $0.004        | $0           | United States |
     | Pine Belt Wireless                          | $0.0035       | $0.0035      | United States |
     | Pine Cellular                               | $0.0035       | $0.0035      | United States |
     | Plivo                                       | $0.004        | $0           | United States |


### PR DESCRIPTION
Changes occurring Sept 1st: 

Short Code SMS
Carrier, SMS MT (new), SMS MO (new)
Cogeco, $0.0035, - 	
Fastwyre, $0.0035, $0.0035
Optimera ,0.004, -

10DLC SMS
Carrier ,SMS MT (increase), SMS MT (no change), SMS MO (new) 
1stPoint/FirstPoint, $0.004, -, $0.004
DISH Wireless, -, $0.0035, $0.0035

**PLEASE READ BELOW**

Please click on the `Preview` tab and then select the appropriate template for your pull request. 
If you do not see a template that fits your pull request, select the `Other Changes` template.

- [Documentation Update & Changes](?labels=area/documentation&expand=1&template=updating_docs.md)
- [REST API Update](?labels=area/rest-api&expand=1&template=rest_api_update.md)
- [Other Changes](?labels=area/general&expand=1&template=other.md)
