### PR TITLE
Update CDN to use latest version of older SDK version

### DIFF
--- a/website/browser-sdk_versioned_docs/version-v2/index.mdx
+++ b/website/browser-sdk_versioned_docs/version-v2/index.mdx
@@ -22,7 +22,7 @@ The Relay SDK for JavaScript is easy to use and only takes a few minute to setup
 You can directly include the bundle file from our CDN:
 
 ```html
-<script src="https://cdn.signalwire.com/libs/js/relay/1.2.7/relay.min.js"></script>
+<script src="https://unpkg.com/@signalwire/js@^1"></script>
 ```
 
 Then, use the global `Relay` variable in your application.


### PR DESCRIPTION
# Documentation Update Pull Request

## Description

Update CDN to always use latest version.

<!-- Delete the `Related Issue` section if there is no related issue open with this Pull Request -->
## Related Issue

https://github.com/signalwire/api-docs/pull/640

## Type of Change

- [ ] New documentation
- [x] Update to existing documentation


## Checklist:

- [x] My documentation follows the [style guidelines](https://github.com/signalwire/signalwire-docs/wiki/Style-Guidelines) of this project
- [x] I have performed a self-review of my documentation
- [x] My changes generate no new warnings
- [x] Builds successfully locally

