### PR TITLE
Temp fix for mediaurl in create a message.

### DIFF
--- a/specs/compatibility-api/_spec_.yaml
+++ b/specs/compatibility-api/_spec_.yaml
@@ -7288,7 +7288,6 @@ paths:
                 - To
                 - From
                 - Body
-                - MediaUrl
               properties:
                 To:
                   type: string


### PR DESCRIPTION
#501 



In the future, this should really be two different types: SMS object & MMS object. Both are valid and make certain properties conditionally required. For now we will mark as optional to help prevent confusion.