### PR TITLE
Changed wording for ruby/c# to not mention python and instead mention…

### DIFF
--- a/website/docs/main/compatibility-api/sdks/index.mdx
+++ b/website/docs/main/compatibility-api/sdks/index.mdx
@@ -173,7 +173,7 @@ When migrating to SignalWire, make sure to replace the `from` numbers with a val
 
     <h3>Initializing the Client</h3>
 
-    In order to use the Python client, you must get your `Space URL`, `Project ID`, and `API Token`
+    In order to use the Ruby client, you must get your `Space URL`, `Project ID`, and `API Token`
     from your SignalWire Dashboard and initialize the client:
 
     ```ruby
@@ -240,7 +240,7 @@ When migrating to SignalWire, make sure to replace the `from` numbers with a val
 
     <h3>Initializing the Client</h3>
 
-    In order to use the Python client, you must get your `Space URL`, `Project ID`, and `API Token`
+    In order to use the C# client, you must get your `Space URL`, `Project ID`, and `API Token`
     from your SignalWire Dashboard and initialize the client:
 
     ```csharp


### PR DESCRIPTION
# Documentation Update Pull Request

## Description

Changed wording for ruby/c# to not mention python and instead mention themselves.

<!-- Delete the `Related Issue` section if there is no related issue open with this Pull Request -->
## Related Issue

If there's an issue available, link it here: #557 

## Type of Change

- [x] Update to existing documentation

### Documentation Change Details

Changed wording for ruby/c# to not mention python and instead mention themselves. (to initialize ruby client, to initialize c# client, etc.)


## Motivation and Context

Solves #557 

## Checklist:

- [x] My documentation follows the [style guidelines](https://github.com/signalwire/signalwire-docs/wiki/Style-Guidelines) of this project
- [x] I have performed a self-review of my documentation
- [x] My changes generate no new warnings
- [x] Builds successfully locally
