### PR TITLE
fix circular redirect

### DIFF
--- a/website/provisioning/nginx/redirects.map
+++ b/website/provisioning/nginx/redirects.map
@@ -556,8 +556,6 @@
 /rest/signalwire-rest/endpoints/fabric/delete-video-room/ /rest/signalwire-rest/endpoints/fabric/delete-conference-room;
 /rest/signalwire-rest/endpoints/fabric/create-guest-tokens /rest/signalwire-rest/endpoints/fabric/guest-tokens-create;
 /rest/signalwire-rest/endpoints/fabric/create-guest-tokens/ /rest/signalwire-rest/endpoints/fabric/guest-tokens-create;
-/rest/signalwire-rest/endpoints/fabric/invite-tokens-create /rest/signalwire-rest/endpoints/fabric/invite-tokens-create;
-/rest/signalwire-rest/endpoints/fabric/invite-tokens-create/ /rest/signalwire-rest/endpoints/fabric/invite-tokens-create;
 /rest/signalwire-rest/endpoints/fabric/subscriber-sip-endpoint-list /rest/signalwire-rest/endpoints/fabric/subscriber-sip-endpoint-list;
 /rest/signalwire-rest/endpoints/fabric/subscriber-sip-endpoint-list/ /rest/signalwire-rest/endpoints/fabric/subscriber-sip-endpoint-list;
 /rest/signalwire-rest/endpoints/fabric/subscriber-sip-endpoint-create /rest/signalwire-rest/endpoints/fabric/subscriber-sip-endpoint-create;


### PR DESCRIPTION
quick fix for this link: https://developer.signalwire.com/rest/signalwire-rest/endpoints/fabric/invite-tokens-create