### PR TITLE
Removed params that do not exist from example.

### DIFF
--- a/website/docs/main/swml/guides/deployment.mdx
+++ b/website/docs/main/swml/guides/deployment.mdx
@@ -48,8 +48,6 @@ The following is an example JSON that you might receive as a POST request on you
     "type": "phone",
     "from": "<CALLING PHONE NUMBER>",
     "to": "<THE NUMBER ATTACHED TO THE SWML>",
-    "from_number": "<CALLING PHONE NUMBER>",
-    "to_number": "<NUMBER ATTACHED TO THE SWML>",
     "headers": [],
     "project_id": "<YOUR PROJECT ID>",
     "space_id": "<YOUR SPACE ID>"
@@ -173,4 +171,5 @@ Every time a call is received, the SWML script is executed using the `client.exe
 
 - **[Handle incoming calls from code](/swml/guides/remote_server)**: Complete guide to serving SWML from web servers
 - **[SWML methods reference](/swml/methods)**: Explore all available SWML methods
+
 - **[Getting started with SWML](/swml)**: Learn the fundamentals


### PR DESCRIPTION

# Documentation Update Pull Request

## Description

removed params from example in https://developer.signalwire.com/swml/guides/deployment :

to.number
from.number 

## Type of Change

- [x] Update to existing documentation

## Motivation and Context

Params are never returned, should not be in example

## Checklist:

- [x] My documentation follows the [style guidelines](https://github.com/signalwire/docs/wiki/Written-Style-Guide) of this project
- [x] I have performed a self-review of my documentation
- [x] My changes generate no new warnings
- [x] Builds successfully locally
