### PR TITLE
Fix circular card ref in SW REST overview

### DIFF
--- a/website/docs/main/rest/signalwire-rest/guides/index.mdx
+++ b/website/docs/main/rest/signalwire-rest/guides/index.mdx
@@ -2,6 +2,8 @@
 title: Overview
 sidebar_position: 0
 slug: /rest/signalwire-rest/guides
+sidebar_custom_props:
+  hideFromIndex: true
 ---
 
 A collection of guides that help you get the most out of the SignalWire REST API.


### PR DESCRIPTION
quick fix

There was a card that linked to itself