### PR TITLE
Remove codesandbox examples

### DIFF
--- a/website/blog/releases/js/3.8.0/index.mdx
+++ b/website/blog/releases/js/3.8.0/index.mdx
@@ -49,7 +49,6 @@ await chatClient.publish({
 
 Please explore the following resources for more information:
  - [Technical Reference](/sdks/browser-sdk/chat)
- - [Example Application](https://codesandbox.io/s/basic-chat-vanilla-js-and-node-2u5lf?file=/frontend/index.js)
  - [Tutorial](/chat/getting-started/get-started-with-a-simple-chat-demo)
 
 ### List of members in a video room

--- a/website/docs/browser-sdk/guides/video/get-thumbnails-for-your-video-calls/index.mdx
+++ b/website/docs/browser-sdk/guides/video/get-thumbnails-for-your-video-calls/index.mdx
@@ -172,6 +172,4 @@ export default function App() {
 
 ### Demo
 
-If you'd like to explore and tinker with this feature, you can do so right from the browser in [Code Sandbox](https://codesandbox.io/s/room-preview-demo-zb2urs).
-
 The demo code is also available on [GitHub](https://github.com/signalwire/guides/tree/main/Video/Room%20Preview%20Demo).

--- a/website/docs/browser-sdk/guides/video/sharing-your-screen-with-the-signalwire-video-sdk/index.mdx
+++ b/website/docs/browser-sdk/guides/video/sharing-your-screen-with-the-signalwire-video-sdk/index.mdx
@@ -74,7 +74,3 @@ You can call the `toggle_screen_share` function from your "Share Screen" button 
 ```html
 <button onclick="toggle_screen_share()">Toggle Screen Share</button>
 ```
-
-### Try it out
-
-You can try tinkering with a demo on [CodeSandbox](https://codesandbox.io/s/serverless-sound-9omwz).

--- a/website/docs/browser-sdk/guides/video/switch-webcam-or-microphone-with-signalwire-video-api.mdx
+++ b/website/docs/browser-sdk/guides/video/switch-webcam-or-microphone-with-signalwire-video-api.mdx
@@ -88,7 +88,3 @@ roomSession.updateMicrophone({
 ```
 
 _Note that you don't explicitly have to update camera and microphone. SignalWire Video SDK chooses the preferred input devices by default on setup. Only `updateCamera` or `updateMicrophone` when you want to switch to a non-default device._
-
-## A complete code example
-
-A complete demo of switching between examples is available for you to read and experiment on [CodeSandbox](https://codesandbox.io/s/lingering-glitter-r8bxl). You can tinker with the code without leaving your browser. The functions of interest to us here are at `src/frontend/index.js`. Look for functions `populateMicrophone()` and `populateCamera()`.

--- a/website/docs/browser-sdk/guides/video/video-overlays.mdx
+++ b/website/docs/browser-sdk/guides/video/video-overlays.mdx
@@ -116,8 +116,6 @@ Finally, we need to trigger `updateOverlay`. We do that during mouse events on t
 
 You can obtain more information about what is currently displayed within a given layer (for example, the memberId) by exploring the fields of the objects in the `currLayout.layers` array.
 
-You can find the complete application on CodeSandbox, and on GitHub in the branch "extras":
+You can find the complete application on GitHub in the branch "extras":
 
-- Backend [CodeSandbox](https://codesandbox.io/s/8gv4h)
-- Frontend [CodeSandbox](https://codesandbox.io/s/i4h64)
 - GitHub: [Repo](https://github.com/signalwire/browser-videoconf-full-react/tree/extras)

--- a/website/docs/main/home/calling/video/get-started/getting-started-with-the-signalwire-video-api-1/index.mdx
+++ b/website/docs/main/home/calling/video/get-started/getting-started-with-the-signalwire-video-api-1/index.mdx
@@ -31,11 +31,6 @@ When the site is finished, it will look something like this:
 </Frame>
 
 
-Before we begin, try using the [demo app](https://codesandbox.io/s/simple-video-demo-1ntfr2?file=/src/frontend/index.js).
-This is what we will build, step by step. Feel free to explore the codebase.
-You don't necessarily have to understand everything right now, but try tinkering with it.
-When you're ready, let's set up API access.
-
 ## Obtaining your API key and Project ID
 
 First, we will need access to the SignalWire APIs.
@@ -299,8 +294,6 @@ roomSession.on("member.left", (e) => logevent(e.member.id + " has left the room"
 ### Putting it All Together
 
 All the above ideas can be combined to create the following function, which we'll use (with minor variations) in the frontend.
-Please note this snippet includes references to a user interface which you can see in our
-[demo](https://codesandbox.io/s/simple-video-demo-1ntfr2?file=/src/frontend/index.js).
 
 ```javascript
 async function join() {

--- a/website/docs/main/home/calling/video/get-started/video-first-steps/index.mdx
+++ b/website/docs/main/home/calling/video/get-started/video-first-steps/index.mdx
@@ -67,10 +67,7 @@ Create an HTML file. Copy the following content to create a basic video room:
 
 In the above file, we are using the [Browser SDK](/sdks/browser-sdk) to establish a video connection to a video room and to display its video stream into a `div`.
 
-To see it in action, you need to serve the HTML through a web server. You can upload it anywhere you like or, if you prefer, you can either:
-
-- test it in our [live demo](https://codesandbox.io/s/getting-started-42v0s?file=/index.html): open the link and you'll be able to try it out right away. Or,
-- test it locally. Here's how:
+To see it in action, you need to serve the HTML through a web server. You can upload it anywhere you like or, if you prefer, you can test it locally. Here's how:
 
 ### Step 1: Install Node.js
 

--- a/website/docs/main/home/calling/video/guides/layout-positions/index.mdx
+++ b/website/docs/main/home/calling/video/guides/layout-positions/index.mdx
@@ -17,7 +17,7 @@ SignalWire Video APIs provide a powerful layout system that you can use in your 
 
 This guide assumes that you have a video already set up in a web page. Follow [First steps with Video](/video/getting-started/video-first-steps) if you need help getting started.
 
-If you want to test this, check out our example in [CodeSandbox](https://codesandbox.io/s/positions-for-layouts-vsy5v9).
+The full code to layout positions is on GitHub [examples/Video/Layout-Positions](https://github.com/signalwire/examples/tree/main/Video/Layout-Positions)
 
 ## Listing and setting layouts
 

--- a/website/docs/main/home/calling/video/guides/setting-the-layout-of-your-signalwire-video-calls.mdx
+++ b/website/docs/main/home/calling/video/guides/setting-the-layout-of-your-signalwire-video-calls.mdx
@@ -112,8 +112,6 @@ If calling the `.setLayout()` method throws an `insufficient permission` error, 
 Demo
 ----
 
-You can try using and tinkering with the sample program below on [CodeSandbox](https://codesandbox.io/s/affectionate-tharp-rucj7).
-
 This demo was built in the [Simple Video Demo](/video/getting-started/simple-video-demo). If you're having trouble understanding this demo, get started over there before adding layout in this guide.
 
 Key Points

--- a/website/docs/main/home/messaging/chat/getting-started/get-started-with-a-simple-chat-demo/index.mdx
+++ b/website/docs/main/home/messaging/chat/getting-started/get-started-with-a-simple-chat-demo/index.mdx
@@ -21,12 +21,9 @@ In this guide we will explore a simple chat application built using the SignalWi
     </figcaption>
 </figure>
 
-The Frontend
-------------
+## The Frontend
 
 Using the SignalWire JavaScript SDK you can easily integrate chat features into any web application. It only takes a few minutes to set up a basic example.
-
-We have prepared for you a simple live example which will be the reference implementation for this guide. Please check it out [here](https://codesandbox.io/s/basic-chat-vanilla-js-and-node-2u5lf?file=/frontend/index.js).
 
 ### Connection
 
@@ -55,14 +52,14 @@ try {
 
 The `Client` constructor takes a `token` parameter. This is an authentication token that defines (among other things) the channels which the client is allowed to read and write. When you call `chatClient.subscribe`, you must make sure that the channels you're subscribing to are allowed by the token.
 
-#### How to obtain a token?
+### How to obtain a token?
 
-Tokens are provided to the client by your own custom server. Your server determines whether the user is actually authorized to access the chat and, if they are, asks SignalWire to emit a token. We will see later how to write such server. For now, we will get a token from a public demo server.
-
-Our demo server is located at `https://2u5lf.sse.codesandbox.io:8080`.  To obtain the Chat Token from our demo server, we can perform a POST request to the `/get_chat_token` endpoint as shown below.
+Tokens are provided to the client by your own custom server. Your server determines whether the user is actually authorized to access the chat and, if they are, asks SignalWire to emit a token. 
+The token is supplied to us by the [Backend](#the-backend) section of this guide, which we will explore shortly. For now, replace `<localhost:port>` with the localhost address and port of your server. If you're using the code sample below,
+replace `<localhost:port>` with `http://localhost:8080`.
 
 ```javascript
-const reply = await axios.post("https://2u5lf.sse.codesandbox.io:8080/get_chat_token", {
+const reply = await axios.post("http://<localhost:port>/get_chat_token", {
   member_id: memberId,
   channels: channels
 });
@@ -72,11 +69,70 @@ const token = reply.data.token;
 
 Notice how we specify a member_id (which can be any unique string of your choice) and a list of channels that should be allowed in the token. This interface is not specific to the SignalWire SDK: when you will write your own server, you will be free to specify any parameters you need for the `/get_chat_token` endpoint.
 
+## The Backend
+
+The backend is the proxy which should handle all your authentication logic. The backend is responsible to ensure the user requesting the token is authorized to access the chat and, if they are, ask SignalWire to emit a token.
+The token from SignalWire is then sent to the frontend to be used to initialize the chat client.
+
+Consider the Express.js example below:
+
+```javascript
+require("dotenv").config();
+const auth = {
+  username: process.env.PROJECT_ID, // Project-ID
+  password: process.env.API_TOKEN, // API token
+};
+const apiurl = `https://${process.env.SPACE_URL}`;
+
+const axios = require("axios")
+const express = require("express");
+const bodyParser = require("body-parser");
+const cors = require("cors");
+
+const app = express()
+const port = 8080
+
+app.use(bodyParser.json());
+app.use(cors());
+
+app.use(express.static('frontend'))
+
+app.post("/get_chat_token", async (req, res) => {
+  const { member_id, channels } = req.body;
+
+  const channelsPerms = {}
+  for (const c of channels) {
+    channelsPerms[c] = { read: true, write: true }
+  }
+
+  const reply = await axios.post(
+    apiurl + "/api/chat/tokens",
+    {
+      ttl: 50,
+      channels: channelsPerms,
+      member_id,
+      state: {},
+    },
+    { auth }
+  )
+
+  res.json({
+    token: reply.data.token
+  })
+});
+
+app.listen(port, () => {
+  console.log(`Example app listening on port ${port}`)
+})
+```
+
+The backend technology and stack is not relevant. The important part is that the SignalWire Chat REST API is called to [Generate a new Chat Token](/rest/signalwire-rest/endpoints/chat/chat-tokens-create) with the appropriate parameters.
+
 This is all you need to get the chat up and running.
 
-### Downloading the existing messages
+## Downloading the existing messages
 
-After you join a channel, you will likely want to download a list of messages that were sent into that channel. SignalWire stores the messages for you so that you can use the `getMessages` method of the SDK to get the JSON list. Here is how we do it in the live example:
+After you join a channel, you will likely want to download a list of messages that were sent into that channel. SignalWire stores the messages for you so that you can use the `getMessages` method of the SDK to get the JSON list. 
 
 ```js
 /**
@@ -103,7 +159,7 @@ for (const channel of channels) {
 
 For each of the channels we're subscribing to, we call `chatClient.getMessages`. For each message, we then call `displayMessage` to display it in the UI.
 
-### Receiving incoming messages
+## Receiving incoming messages
 
 If you want to receive incoming messages for the channels you've subscribed to, you just have to listen to the `message` event. For example:
 
@@ -120,7 +176,7 @@ chatClient.on("message", (message) => {
 
 This will call `displayMessage` each time a new message is received.
 
-### Sending a message
+## Sending a message
 
 Sending a message is just a method call. This will send your message into the specified channel:
 
@@ -133,11 +189,11 @@ await chatClient.publish({
 
 Note that your message doesn't necessarily have to be a string! It can be any JSON-serializable object.
 
-### Displaying "is typing" indicator
+## Displaying "is typing" indicator
 
 To display a "member is typing" indicator we can exploit the member state management of the SDK. Each member has an associated state, which can be controlled from the SDK. We can use this state to store a boolean which indicates whether a member is currently typing. The state is shared across all members, so they can update their UI to show the indicator.
 
-To set the typing state, you will need to subscribe to the `keyup` event for the textarea in which users type their messages. Please refer to the [live example](https://codesandbox.io/s/basic-chat-vanilla-js-and-node-2u5lf?file=/frontend/index.js) for details on this. At the end, here is how the state is updated:
+To set the typing state, you will need to subscribe to the `keyup` event for the textarea in which users type their messages. At the end, here is how the state is updated:
 
 ```js
 chatClient.setMemberState({
@@ -173,7 +229,6 @@ We have built a basic chat application. With just a few lines of code, our appli
 Here are a few resources to learn more about the chat:
 
 - [Technical Reference](/sdks/browser-sdk/chat)
-- [Example Application](https://codesandbox.io/s/basic-chat-vanilla-js-and-node-2u5lf?file=/frontend/index.js)
 
 Sign Up Here
 ------------

--- a/website/docs/main/home/messaging/chat/guides/build-a-react-chat-application/index.mdx
+++ b/website/docs/main/home/messaging/chat/guides/build-a-react-chat-application/index.mdx
@@ -26,7 +26,7 @@ When building a frontend communication application, you have probably had to dea
 
 ## The Frontend
 
-We have prepared a simple live example which will be the reference implementation for this guide. Please check out the [Sandbox](https://codesandbox.io/s/react-chat-ep9x75?file=/src/pages/Home.js). You can also find the same sample code on [GitHub](https://github.com/signalwire/simple-chat-in-react/tree/main/frontend).
+The code for the frontend of this guide is available on [GitHub](https://github.com/signalwire/simple-chat-in-react/tree/main/frontend).
 
 ### Components
 
@@ -78,7 +78,7 @@ Notice that when we request a token, we specify a member_id (which can be any un
 
 :::info How to obtain a token?
 
-Tokens are provided to the client by your custom server. Your server determines whether the user is authorized to access the chat and, if they are, asks SignalWire to emit a token. For demo purposes, you can obtain a public access token from our demo server. To do so, set `SERVERLOCATION` to `https://2u5lf.sse.codesandbox.io:8080`. If you would like to build your own backend for a production-quality application, see the [Backend](#the-backend) section for guidance.
+Tokens are provided to the client by your custom server. Your server determines whether the user is authorized to access the chat and, if they are, asks SignalWire to emit a token. You need to host the [Backend](#the-backend) and set that as the `SERVERLOCATION`. 
 
 :::
 
@@ -143,7 +143,7 @@ Although we've set our default message state as a string, your message doesn't n
 
 Even though SignalWire provides the platform for all chat communications when using the Chat APIs, you still need to write some server-side logic to proxy the SignalWire REST APIs. Your server-side script should work to authenticate your users, manage their permissions, and relay the tokens from the SignalWire's Chat REST APIs to the client's browser. The token has information like the `member_id` (which we call username in the UI) and the channel permissions for the token's user. The JavaScript SDK running in the client's browser will then use the token to establish a direct connection with the SignalWire servers.
 
-We prepared a live sample proxy server on [Code Sandbox](https://codesandbox.io/s/chat-backend-uh78zo?file=/index.js). This is the server that supports the frontend linked above. It is a fairly simple setup:
+The code for the backend of this guide is available on [GitHub](https://github.com/signalwire/simple-chat-in-react/).
 
 ```js
 require("dotenv").config();
@@ -237,8 +237,6 @@ That's all it takes to develop your Chat application with React. We built a stan
 Here is a quick list of the resources discussed here if you want to refer back:
 
 - [Technical Reference](/sdks/browser-sdk/chat)
-- [Example Frontend Application](https://codesandbox.io/s/react-chat-ep9x75?file=/src/pages/Home.js)
-- [Example Proxy Server](https://codesandbox.io/s/chat-backend-uh78zo?file=/index.js)
 - [GitHub Repo](https://github.com/signalwire/simple-chat-in-react)
 
 ## Sign Up


### PR DESCRIPTION
# Documentation Update Pull Request

## Description

As per [#643](https://github.com/signalwire/docs/issues/643) we don't want to be using codesandbox anymore. I've removed the links. The GitHub repo generally has everything required for the user to run the examples locally anyway.
For some projects, I've made minor modifications to ensure the guide is still functional without CodeSandbox.

## Type of Change

- [ ] New documentation
- [x] Update to existing documentation

### Documentation Change Details
- **Changes Summary**: Removed codesandbox links
 
## Motivation and Context

[#643](https://github.com/signalwire/docs/issues/643)

## Checklist:

- [x] My documentation follows the [style guidelines](https://github.com/signalwire/docs/wiki/Written-Style-Guide) of this project
- [x] I have performed a self-review of my documentation
- [x] My changes generate no new warnings
- [ ] Builds successfully locally
