### PR TITLE
remove unnecessary component imports

### DIFF
--- a/website/docs/browser-sdk/guides/video/recording-video/index.mdx
+++ b/website/docs/browser-sdk/guides/video/recording-video/index.mdx
@@ -148,8 +148,6 @@ You can get a list of all videos that have been recorded with a `GET` request at
 The request returns a JSON object with a paginated array of all room recordings, including the id of the room
 session which was recorded, and a `uri` string that you can use to download the recording.
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 
 <Tabs groupId="pvc-vs-sdk">
   <TabItem value="curl" label="curl" default>

--- a/website/docs/browser-sdk/tech-ref/SignalWire Client/client/index.mdx
+++ b/website/docs/browser-sdk/tech-ref/SignalWire Client/client/index.mdx
@@ -362,7 +362,6 @@ client.conversation.getConversations();
 [`Chat`]: /sdks/browser-sdk/signalwire-client/client/chat
 [`Conversation`]: /sdks/browser-sdk/signalwire-client/client/conversation
 
-import DocCardList from "@theme/DocCardList";
 
 <DocCardList />
 

--- a/website/docs/main/call-flow-builder/nodes/conditions/index.mdx
+++ b/website/docs/main/call-flow-builder/nodes/conditions/index.mdx
@@ -43,7 +43,6 @@ The "Cond #" path will be executed for a truthy condition. The "Else" path will 
 In this example, we immediately hang up calls from specific numbers on our block list and forward call from a VIP directly to our administration number. 
 All other calls will connect to the main reception number.
 
-import Frame from '@site/src/components/Extras/Frame/Frame';
 
 <Frame caption="Block or pass through calls based on caller number." ogImage>
 

--- a/website/docs/main/call-flow-builder/nodes/execute_swml/index.mdx
+++ b/website/docs/main/call-flow-builder/nodes/execute_swml/index.mdx
@@ -41,7 +41,6 @@ The SWML document will return a JSON object with a [play](/swml/methods/play) me
 This play field will be used for TTS (Text-to-Speech) in the current document
 and will welcome the user with the `User` parameter and say the `Token` parameter.
 
-import Frame from '@site/src/components/Extras/Frame/Frame';
 
 <Frame caption="Call Flow using the Execute SWML node." ogImage>
 

--- a/website/docs/main/compatibility-api/api-reference/rest-client-sdks/methods/accounts/list.mdx
+++ b/website/docs/main/compatibility-api/api-reference/rest-client-sdks/methods/accounts/list.mdx
@@ -3,8 +3,6 @@ slug: /compatibility-api/client-sdks/methods/accounts/list
 title: List
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 
 # List All Accounts
 

--- a/website/docs/main/compatibility-api/api-reference/rest-client-sdks/methods/accounts/retrieve.mdx
+++ b/website/docs/main/compatibility-api/api-reference/rest-client-sdks/methods/accounts/retrieve.mdx
@@ -3,8 +3,6 @@ slug: /compatibility-api/client-sdks/methods/accounts/retrieve
 title: Retrieve
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 
 # Retrieve an Account
 

--- a/website/docs/main/compatibility-api/api-reference/rest-client-sdks/methods/accounts/update-friendly-name.mdx
+++ b/website/docs/main/compatibility-api/api-reference/rest-client-sdks/methods/accounts/update-friendly-name.mdx
@@ -3,8 +3,6 @@ slug: /compatibility-api/client-sdks/methods/accounts/update
 title: Update
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 
 # Update an Account
 

--- a/website/docs/main/compatibility-api/cxml/fax/index.mdx
+++ b/website/docs/main/compatibility-api/cxml/fax/index.mdx
@@ -4,8 +4,6 @@ excerpt: ""
 slug: /compatibility-api/cxml/fax
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 
 Fax cXML is a set of actions defined in an XML document you can use to tell SignalWire what to do when you receive an incoming fax.
 

--- a/website/docs/main/compatibility-api/cxml/fax/receive.mdx
+++ b/website/docs/main/compatibility-api/cxml/fax/receive.mdx
@@ -4,8 +4,6 @@ excerpt: ""
 slug: /compatibility-api/cxml/fax/receive
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 
 The `<Receive>` verb tells SignalWire to receive an incoming fax, which results in the creation of a new Fax instance resource.
 

--- a/website/docs/main/compatibility-api/cxml/fax/reject.mdx
+++ b/website/docs/main/compatibility-api/cxml/fax/reject.mdx
@@ -4,8 +4,6 @@ excerpt: ""
 slug: /compatibility-api/cxml/fax/reject
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 
 The `<Reject>` verb tells SignalWire to reject an incoming fax, which results in a status of `canceled`.
 

--- a/website/docs/main/compatibility-api/cxml/messaging/index.mdx
+++ b/website/docs/main/compatibility-api/cxml/messaging/index.mdx
@@ -4,8 +4,6 @@ excerpt: ""
 slug: /compatibility-api/cxml/messaging
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 
 SignalWire cXML is a set of actions defined in an XML document that you can use to tell SignalWire what to do when you receive an incoming SMS or MMS message.
 

--- a/website/docs/main/compatibility-api/cxml/messaging/message.mdx
+++ b/website/docs/main/compatibility-api/cxml/messaging/message.mdx
@@ -4,8 +4,6 @@ excerpt: ""
 slug: /compatibility-api/cxml/messaging/message
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 
 The `<Message>` verb sends an SMS or MMS message to a phone number. To send a message in combination with [Voice XML](../voice/index.mdx) verbs, use the [`<Sms>` Voice verb](../voice/sms.mdx).
 

--- a/website/docs/main/compatibility-api/cxml/messaging/redirect.mdx
+++ b/website/docs/main/compatibility-api/cxml/messaging/redirect.mdx
@@ -4,8 +4,6 @@ excerpt: ""
 slug: /compatibility-api/cxml/messaging/redirect
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 
 The `<Redirect>` verb transfers control from the current document to another. It is effectively an exit statement from the current document, as there is no way to return to any instructions listed after the `<Redirect>` verb.
 

--- a/website/docs/main/compatibility-api/cxml/voice/_ai-noun.mdx
+++ b/website/docs/main/compatibility-api/cxml/voice/_ai-noun.mdx
@@ -3,8 +3,6 @@ title: <AI> noun
 slug: /compatibility-api/cxml/voice/ai-noun
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 
 [`<Connect>`](./connect.mdx) verb's `<AI>` noun allows the connection to a virtual AI agent.
 For example:

--- a/website/docs/main/compatibility-api/cxml/voice/conference-noun.mdx
+++ b/website/docs/main/compatibility-api/cxml/voice/conference-noun.mdx
@@ -3,8 +3,6 @@ title: <Conference> noun
 slug: /compatibility-api/cxml/voice/conference-noun
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 
 [`<Dial>`](./dial.mdx) verb's `<Conference>` noun allows the connection to a named conference room.
 For example:

--- a/website/docs/main/compatibility-api/cxml/voice/connect.mdx
+++ b/website/docs/main/compatibility-api/cxml/voice/connect.mdx
@@ -3,8 +3,6 @@ title: <Connect>
 slug: /compatibility-api/cxml/voice/connect
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 
 The `<Connect>` verb connects an existing call to another resource.
 

--- a/website/docs/main/compatibility-api/cxml/voice/dial.mdx
+++ b/website/docs/main/compatibility-api/cxml/voice/dial.mdx
@@ -3,8 +3,6 @@ title: <Dial>
 slug: /compatibility-api/cxml/voice/dial
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 
 The `<Dial>` verb connects an existing call to another phone number. `<Dial>` will end this new call if: the called number does not answer, the number does not exist, or SignalWire receives a busy signal.
 

--- a/website/docs/main/compatibility-api/cxml/voice/echo.mdx
+++ b/website/docs/main/compatibility-api/cxml/voice/echo.mdx
@@ -3,8 +3,6 @@ title: <Echo>
 slug: /compatibility-api/cxml/voice/echo
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 
 The `<Echo>` verb will echo audio back to the call.
 

--- a/website/docs/main/compatibility-api/cxml/voice/enqueue.mdx
+++ b/website/docs/main/compatibility-api/cxml/voice/enqueue.mdx
@@ -3,8 +3,6 @@ title: <Enqueue>
 slug: /compatibility-api/cxml/voice/enqueue
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 
 The `<Enqueue>` verb places a call in a specified call queue. If the specified queue does not exist, a new queue will be created and the call will be placed into that new queue. Calls can be dequeued through the `<Dial>` verb or removed from the queue through the `<Leave>` verb.
 

--- a/website/docs/main/compatibility-api/cxml/voice/gather.mdx
+++ b/website/docs/main/compatibility-api/cxml/voice/gather.mdx
@@ -3,8 +3,6 @@ title: <Gather>
 slug: /compatibility-api/cxml/voice/gather
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 
 The `<Gather>` verb transcribes speech or collects digits during a call.
 

--- a/website/docs/main/compatibility-api/cxml/voice/hangup.mdx
+++ b/website/docs/main/compatibility-api/cxml/voice/hangup.mdx
@@ -3,8 +3,6 @@ title: <Hangup>
 slug: /compatibility-api/cxml/voice/hangup
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 
 The `<Hangup>` verb ends a call. While `<Reject>`ed calls are never answered, calls that use the `<Hangup>` verb for disconnection are still answered, becoming subject to billing.
 

--- a/website/docs/main/compatibility-api/cxml/voice/index.mdx
+++ b/website/docs/main/compatibility-api/cxml/voice/index.mdx
@@ -3,8 +3,6 @@ title: Voice XML
 slug: /compatibility-api/cxml/voice
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 
 SignalWire cXML is a set of actions defined in an XML document you can use to tell SignalWire what to do when you receive an incoming call or instructions for outbound calls.
 

--- a/website/docs/main/compatibility-api/cxml/voice/leave.mdx
+++ b/website/docs/main/compatibility-api/cxml/voice/leave.mdx
@@ -3,8 +3,6 @@ title: <Leave>
 slug: /compatibility-api/cxml/voice/leave
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 
 The `<Leave>` verb transfers a call out of the queue containing that call. It then returns the flow of execution to verb following the `<Enqueue>` that placed this call into the queue.
 

--- a/website/docs/main/compatibility-api/cxml/voice/number-noun.mdx
+++ b/website/docs/main/compatibility-api/cxml/voice/number-noun.mdx
@@ -4,8 +4,6 @@ excerpt: ""
 slug: /compatibility-api/cxml/voice/number-noun
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 
 [`<Dial>`](./dial.mdx) verb's `<Number>` noun specifies what phone number to dial. You can use up to 10 `<Number>`s within a `<Dial>` to simultaneously call several people. The first person to answer the call will be connected to the caller and the rest of the called numbers will be hung up.
 

--- a/website/docs/main/compatibility-api/cxml/voice/pause.mdx
+++ b/website/docs/main/compatibility-api/cxml/voice/pause.mdx
@@ -3,8 +3,6 @@ title: <Pause>
 slug: /compatibility-api/cxml/voice/pause
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 
 The `<Pause>` verb waits silently for a distinctive number of seconds.
 

--- a/website/docs/main/compatibility-api/cxml/voice/play.mdx
+++ b/website/docs/main/compatibility-api/cxml/voice/play.mdx
@@ -3,8 +3,6 @@ title: <Play>
 slug: /compatibility-api/cxml/voice/play
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 
 The `<Play>` verb plays an audio file, which SignalWire fetches from the URL you configured, back to the caller.
 

--- a/website/docs/main/compatibility-api/cxml/voice/queue-noun.mdx
+++ b/website/docs/main/compatibility-api/cxml/voice/queue-noun.mdx
@@ -3,8 +3,6 @@ title: <Queue> noun
 slug: /compatibility-api/cxml/voice/queue-noun
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 
 [`<Dial>`](./dial.mdx) verb's `<Queue>` noun specifies what queue to dial.
 

--- a/website/docs/main/compatibility-api/cxml/voice/record.mdx
+++ b/website/docs/main/compatibility-api/cxml/voice/record.mdx
@@ -3,8 +3,6 @@ title: <Record>
 slug: /compatibility-api/cxml/voice/record
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 
 The `<Record>` verb creates an audio file with the caller's voice and returns the URL to you. Text transcriptions of these recorded calls can also be produced.
 

--- a/website/docs/main/compatibility-api/cxml/voice/redirect.mdx
+++ b/website/docs/main/compatibility-api/cxml/voice/redirect.mdx
@@ -3,8 +3,6 @@ title: <Redirect>
 slug: /compatibility-api/cxml/voice/redirect
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 
 An example that redirects the next XML instruction to another call:
 

--- a/website/docs/main/compatibility-api/cxml/voice/refer.mdx
+++ b/website/docs/main/compatibility-api/cxml/voice/refer.mdx
@@ -3,8 +3,6 @@ title: <Refer>
 slug: /compatibility-api/cxml/voice/refer
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 
 The `<Refer>` verb transfers a SIP call in SignalWire to a transfer target using the SIP REFER method. This verb returns upon completion of transfer, on failure of transfer, on hangup, or on time out while waiting for NOTIFY. SignalWire will not hang up after `<Refer>` until all verbs have been processed.
 

--- a/website/docs/main/compatibility-api/cxml/voice/reject.mdx
+++ b/website/docs/main/compatibility-api/cxml/voice/reject.mdx
@@ -3,8 +3,6 @@ title: <Reject>
 slug: /compatibility-api/cxml/voice/reject
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 
 The `<Reject>` verb rejects a call to your SignalWire number. It is effectively an exit statement from the current document, as there is no way to return to any instructions listed after the `<Reject>` verb.
 

--- a/website/docs/main/compatibility-api/cxml/voice/room-noun.mdx
+++ b/website/docs/main/compatibility-api/cxml/voice/room-noun.mdx
@@ -3,8 +3,6 @@ title: <Room> noun
 slug: /compatibility-api/cxml/voice/room-noun
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 
 [`<Connect>`](./connect.mdx) verb's `<Room>` noun allows the connection to a video room.
 For example:

--- a/website/docs/main/compatibility-api/cxml/voice/say.mdx
+++ b/website/docs/main/compatibility-api/cxml/voice/say.mdx
@@ -3,8 +3,6 @@ title: <Say>
 slug: /compatibility-api/cxml/voice/say
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 
 The `<Say>` verb reads the supplied text back to the caller. It is useful for text that is difficult to pre-record. The gender and language in which the text will be read is customizable.
 

--- a/website/docs/main/compatibility-api/cxml/voice/sip-noun.mdx
+++ b/website/docs/main/compatibility-api/cxml/voice/sip-noun.mdx
@@ -3,8 +3,6 @@ title: <Sip> noun
 slug: /compatibility-api/cxml/voice/sip-noun
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 
 [`<Dial>`](./dial.mdx) verb's `<Sip>` noun permits the set up of VoIP sessions using SIP (Session Initiation Protocol). You can send a call to any SIP endpoint.
 

--- a/website/docs/main/compatibility-api/cxml/voice/sms.mdx
+++ b/website/docs/main/compatibility-api/cxml/voice/sms.mdx
@@ -3,8 +3,6 @@ title: <Sms>
 slug: /compatibility-api/cxml/voice/sms
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 
 The `<Sms>` verb sends an SMS message to a phone number during a phone call.
 

--- a/website/docs/main/compatibility-api/cxml/voice/stream.mdx
+++ b/website/docs/main/compatibility-api/cxml/voice/stream.mdx
@@ -3,8 +3,6 @@ title: <Stream>
 slug: /compatibility-api/cxml/voice/stream
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 
 [stream_start]: /rest/compatibility-api/endpoints/create-stream
 [stream_stop]: /rest/compatibility-api/endpoints/update-stream

--- a/website/docs/main/compatibility-api/cxml/voice/virtualagent-noun.mdx
+++ b/website/docs/main/compatibility-api/cxml/voice/virtualagent-noun.mdx
@@ -4,8 +4,6 @@ slug: /compatibility-api/cxml/voice/virtualagent-noun
 sidebar_class_name: deprecated
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 
 
 :::warning Deprecated Notice

--- a/website/docs/main/compatibility-api/guides/general/phone-numbers/how-to-purchase-numbers-in-bulk.mdx
+++ b/website/docs/main/compatibility-api/guides/general/phone-numbers/how-to-purchase-numbers-in-bulk.mdx
@@ -11,8 +11,6 @@ x-custom:
     - language:nodejs
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 
 Overview
 --------

--- a/website/docs/main/compatibility-api/guides/general/phone-numbers/how-to-update-webhooks-in-bulk.mdx
+++ b/website/docs/main/compatibility-api/guides/general/phone-numbers/how-to-update-webhooks-in-bulk.mdx
@@ -11,8 +11,6 @@ x-custom:
     - language:nodejs
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 
 Overview
 --------

--- a/website/docs/main/compatibility-api/guides/general/phone-numbers/list-numbers-to-csv.mdx
+++ b/website/docs/main/compatibility-api/guides/general/phone-numbers/list-numbers-to-csv.mdx
@@ -12,8 +12,6 @@ x-custom:
     - sdk:compatibility
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 
 ## Overview
 

--- a/website/docs/main/compatibility-api/guides/general/phone-numbers/release-numbers.mdx
+++ b/website/docs/main/compatibility-api/guides/general/phone-numbers/release-numbers.mdx
@@ -15,8 +15,6 @@ x-custom:
     - sdk:compatibility
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 
 Overview
 --------

--- a/website/docs/main/compatibility-api/guides/messaging/general/how-to-list-messages-filtered-by-multiple-from-numbers.mdx
+++ b/website/docs/main/compatibility-api/guides/messaging/general/how-to-list-messages-filtered-by-multiple-from-numbers.mdx
@@ -7,8 +7,6 @@ x-custom:
   needs_review: true
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 
 
 Overview

--- a/website/docs/main/compatibility-api/guides/messaging/general/how-to-list-messages-with-a-specific-error-code-to-csv.mdx
+++ b/website/docs/main/compatibility-api/guides/messaging/general/how-to-list-messages-with-a-specific-error-code-to-csv.mdx
@@ -7,8 +7,6 @@ x-custom:
   needs_review: true
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 
 Overview
 --------

--- a/website/docs/main/compatibility-api/guides/messaging/general/how-to-pull-undelivered-messages.mdx
+++ b/website/docs/main/compatibility-api/guides/messaging/general/how-to-pull-undelivered-messages.mdx
@@ -7,8 +7,6 @@ x-custom:
   needs_review: true
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 
 ## Overview
 

--- a/website/docs/main/compatibility-api/guides/messaging/general/list-messages-to-csv-all-languages.mdx
+++ b/website/docs/main/compatibility-api/guides/messaging/general/list-messages-to-csv-all-languages.mdx
@@ -7,8 +7,6 @@ x-custom:
   needs_review: true
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 
 ## Overview
 

--- a/website/docs/main/compatibility-api/guides/messaging/general/sms-status-callbacks.mdx
+++ b/website/docs/main/compatibility-api/guides/messaging/general/sms-status-callbacks.mdx
@@ -19,8 +19,6 @@ This script utilizes SMS status callbacks to show a simple delivery status track
 You can learn more about SMS callbacks, all of the possible parameters you can use, and how to set them up in our [status callback mega guide](/compatibility-api/guides/signalwire-status-callbacks#sms-status-callbacks)!
 
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 
 <details>
   <summary>Full code example: SMS Status Callbacks</summary>

--- a/website/docs/main/compatibility-api/guides/voice/nodejs/answering-machine-detection/index.mdx
+++ b/website/docs/main/compatibility-api/guides/voice/nodejs/answering-machine-detection/index.mdx
@@ -31,8 +31,6 @@ The cXML API can create an outbound call with AMD by setting certain parameters 
 
 The call may look something like the following:
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 
 <Tabs groupId="amd-call">
 

--- a/website/docs/main/compatibility-api/guides/voice/python/getting-detailed-price-summaries-about-calls/index.mdx
+++ b/website/docs/main/compatibility-api/guides/voice/python/getting-detailed-price-summaries-about-calls/index.mdx
@@ -15,8 +15,6 @@ x-custom:
 This snippet will show how you can utilize the List Calls Endpoint to pull detailed call reports within a specific date range! The results will include some helpful summary stats about total calls, inbound vs outbound, total cost, and total duration. We will also export further detail on a per-call record basis to a CSV for record-keeping or extra review. 
 
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 
 <details>
   <summary>Full code example: How to Get Price Summaries for Voice</summary>

--- a/website/docs/main/compatibility-api/guides/voice/python/list-calls-to-csv-all-languages.mdx
+++ b/website/docs/main/compatibility-api/guides/voice/python/list-calls-to-csv-all-languages.mdx
@@ -6,8 +6,6 @@ x-custom:
   needs_review: true
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 
 These snippets show how you can use SignalWire's API to filter the calls in your project by a number of parameters and then insert the call data into a CSV for your own record keeping.
 

--- a/website/docs/main/compatibility-api/sdks/index.mdx
+++ b/website/docs/main/compatibility-api/sdks/index.mdx
@@ -4,8 +4,6 @@ title: Compatibility Libraries and SDKs
 slug: /compatibility-api/sdks
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 import LamlAdmonition from "/docs/main/_common/_laml-admonition.md";
 
 # Libraries and SDKs

--- a/website/docs/main/events/livewire/swaig-plus-zendesk/index.mdx
+++ b/website/docs/main/events/livewire/swaig-plus-zendesk/index.mdx
@@ -16,9 +16,6 @@ slug: /livewire/integrate-zendesk-signalwire-ai
   </div>
 </div>
 
-import Steps from "@site/src/components/Steps"
-import Subtitle from "@site/src/components/typography/Subtitle"
-import { Card, CardGroup } from "@site/src/components/Extras/Card";
 import { MdCode, MdEdit } from "react-icons/md";
 
 <br/><br/>

--- a/website/docs/main/home/calling/ai/get-started/_ai-swml-get-started.mdx
+++ b/website/docs/main/home/calling/ai/get-started/_ai-swml-get-started.mdx
@@ -7,8 +7,6 @@ description: Deploy a serverless AI Agent and call it over the PSTN in under 5 m
 ---
 
 import Admonition from '@theme/Admonition';
-import Subtitle from "@site/src/components/typography/Subtitle";
-import Steps from "@site/src/components/Steps";
 
 # Get started
 

--- a/website/docs/main/home/calling/ai/guides/Integrations/vapi/inbound-calls.mdx
+++ b/website/docs/main/home/calling/ai/guides/Integrations/vapi/inbound-calls.mdx
@@ -6,7 +6,6 @@ description: Route incoming calls from SignalWire phone numbers to VAPI AI assis
 ---
 
 import Admonition from '@theme/Admonition';
-import { Card, CardGroup } from "@site/src/components/Extras/Card";
 import { LiaPhoneSolid, LiaCodeSolid, LiaBookSolid, LiaToolsSolid } from "react-icons/lia";
 
 [signup]: https://signalwire.com/signup

--- a/website/docs/main/home/calling/ai/guides/Integrations/vapi/outbound-calls.mdx
+++ b/website/docs/main/home/calling/ai/guides/Integrations/vapi/outbound-calls.mdx
@@ -7,7 +7,6 @@ description: Configure VAPI AI assistants to make outbound calls through SignalW
 ---
 
 import Admonition from '@theme/Admonition';
-import { Card, CardGroup } from "@site/src/components/Extras/Card";
 import { LiaPhoneSolid, LiaCodeSolid, LiaBookSolid, LiaHeadsetSolid } from "react-icons/lia";
 
 [signup]: https://signalwire.com/signup

--- a/website/docs/main/home/calling/ai/guides/best-practices-for-ai/index.mdx
+++ b/website/docs/main/home/calling/ai/guides/best-practices-for-ai/index.mdx
@@ -82,8 +82,6 @@ Understanding the prompt's configuration parameters is key to fine-tuning the AI
 - **Frequency Penalty (`frequency_penalty`):** Influences the AI's tendency to repeat itself.
   Positive values discourage repetition.
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 
 <Tabs groupId="prompt_config">
 <TabItem value="yaml" label="YAML">

--- a/website/docs/main/home/calling/fax/getting-started/list-faxes-to-csv-in-all-languages.mdx
+++ b/website/docs/main/home/calling/fax/getting-started/list-faxes-to-csv-in-all-languages.mdx
@@ -10,8 +10,6 @@ x-custom:
   needs_review: true
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 
 
 Step by step walkthroughs will be provided in detail below as the steps and methods vary with each language. The possible parameters that you can filter by are `DateCreatedAfter`, `DateCreatedOnOrBefore`, `To`, and `From`.

--- a/website/docs/main/home/calling/fax/index.mdx
+++ b/website/docs/main/home/calling/fax/index.mdx
@@ -8,9 +8,7 @@ slug: /fax
 <Subtitle>Programmable Fax in the cloud</Subtitle><br /><br />
 
 import Usecases from "./_usecases/_usecases.mdx";
-import Subtitle from "@site/src/components/typography/Subtitle"
 import Admonition from '@theme/Admonition';
-import { Card, CardGroup } from "@site/src/components/Extras/Card";
 import { MdApi, MdCode, MdCompareArrows, MdSecurity, MdArticle } from "react-icons/md";
 
 Prototype, build, and deploy fax applications quickly and at competitive rates

--- a/website/docs/main/home/calling/video/get-started/managing-rooms-with-apis/index.mdx
+++ b/website/docs/main/home/calling/video/get-started/managing-rooms-with-apis/index.mdx
@@ -26,8 +26,6 @@ Your API token should have at least the video scope enabled for all of the API c
 
 First, we can use the API to [create a video room](/rest/signalwire-rest/endpoints/video/create-video-conference) which includes a user interface. We will need to pass our authentication information and room settings. The example below has a small selection of room settings, but you can see all of the possible parameters at the link above.
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 
 <Tabs groupId="create-room">
 

--- a/website/docs/main/home/calling/video/guides/_react/getting-started-video-api-react/index.mdx
+++ b/website/docs/main/home/calling/video/guides/_react/getting-started-video-api-react/index.mdx
@@ -32,8 +32,6 @@ either the `<Video />` component or the `<VideoConference />` from the package. 
 with a valid token, the components and the SDK will handle the messy details needed for setting up a reliable
 video connection between participants.
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 
 <Tabs groupId="pvc-vs-sdk">
   <TabItem value="PVC" label="PVC" default>

--- a/website/docs/main/home/calling/video/guides/_react/using-events-in-react-and-react-native/index.mdx
+++ b/website/docs/main/home/calling/video/guides/_react/using-events-in-react-and-react-native/index.mdx
@@ -22,8 +22,6 @@ The `<Video/>` component emits an `onRoomReady` event with reference to the [`Ro
 
 First, let’s add a button to make it possible to leave the room.
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 
 <Tabs groupId="react-vs-RN">
   <TabItem value="React" label="React" default>

--- a/website/docs/main/home/calling/video/guides/_react/using-hooks-to-track-call-state/index.mdx
+++ b/website/docs/main/home/calling/video/guides/_react/using-hooks-to-track-call-state/index.mdx
@@ -28,8 +28,6 @@ We use the [RoomSession](/sdks/browser-sdk/video/index.mdx) object to stay
 informed about changes, and interact with the room. To access the RoomSession object, we would
 do something like this:
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 
 <Tabs groupId="pvc-vs-sdk">
   <TabItem value="PVC" label="PVC" default>

--- a/website/docs/main/home/calling/video/guides/zoom-clone-2/index.mdx
+++ b/website/docs/main/home/calling/video/guides/zoom-clone-2/index.mdx
@@ -103,8 +103,6 @@ permissions defined in `permissions.ts` which can be assigned to the user.
 Note that the location of this file ensures that this will run server-side at `api/token` endpoint.
 Learn more about Next.js routing [here](https://nextjs.org/docs/routing/introduction).
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 
 <Tabs>
 <TabItem value='token.ts'>

--- a/website/docs/main/home/calling/video/index.mdx
+++ b/website/docs/main/home/calling/video/index.mdx
@@ -5,7 +5,6 @@ sidebar_position: 5
 
 # Video
 
-import { Card, CardGroup } from "@site/src/components/Extras/Card";
 import { MdRestartAlt, MdRouter, MdWeb, MdVideoCall } from "react-icons/md";
 
 <Subtitle>Programmable, lightweight, scalable video conferencing</Subtitle>

--- a/website/docs/main/home/calling/voice/index.mdx
+++ b/website/docs/main/home/calling/voice/index.mdx
@@ -3,9 +3,7 @@ slug: /voice
 sidebar_position: 1
 ---
 
-import Subtitle from "@site/src/components/typography/Subtitle";
 import UseCase from "./_usecases/_useCases.mdx";
-import { Card, CardGroup } from "@site/src/components/Extras/Card";
 import { MdPayment, MdBolt, MdPhone, MdRocket, MdApps, MdApi, MdCompareArrows, MdRouter, MdPhoneInTalk, MdCode, MdDragIndicator, MdDescription, MdPhonelinkSetup, MdHeadsetMic, MdCallSplit, MdPhoneForwarded, MdVoiceChat } from "react-icons/md";
 
 # Voice

--- a/website/docs/main/home/calling/voice/voice-faq.mdx
+++ b/website/docs/main/home/calling/voice/voice-faq.mdx
@@ -4,7 +4,6 @@ sidebar_position: 0
 title: FAQs
 ---
 
-import { Accordion, AccordionGroup } from "@site/src/components/Extras/Accordion"
 
 # Voice FAQs
 

--- a/website/docs/main/home/messaging/chat/chat-faq.mdx
+++ b/website/docs/main/home/messaging/chat/chat-faq.mdx
@@ -6,7 +6,6 @@ x-custom:
   hideInGuideShowcase: true
 ---
 
-import { Accordion, AccordionGroup } from "@site/src/components/Extras/Accordion"
 
 # Chat FAQs
 

--- a/website/docs/main/home/messaging/chat/index.mdx
+++ b/website/docs/main/home/messaging/chat/index.mdx
@@ -4,7 +4,6 @@ sidebar_position: 3
 description: Programmable, integrated, low-latency Chat APIs and SDKs
 ---
 
-import { Card, CardGroup } from "@site/src/components/Extras/Card";
 import { MdMessage, MdChat, MdCode, MdWeb, MdCloud, MdRocket } from "react-icons/md";
 
 # Chat

--- a/website/docs/main/home/messaging/sms/getting-started/sending-your-first-sms/index.mdx
+++ b/website/docs/main/home/messaging/sms/getting-started/sending-your-first-sms/index.mdx
@@ -10,7 +10,6 @@ x-custom:
     - sdk:compatibility
 ---
 
-import Frame from "@site/src/components/Extras/Frame/Frame";
 
 # Sending Your First SMS
 
@@ -62,8 +61,6 @@ your preferred programming language), or you can use [one of our SDKs](/sdks). W
 
 ### Installation
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 
 <Tabs groupId="your-first-api-calls">
 

--- a/website/docs/main/home/messaging/sms/index.mdx
+++ b/website/docs/main/home/messaging/sms/index.mdx
@@ -3,9 +3,7 @@ slug: /messaging
 sidebar_position: 2
 ---
 
-import { Card, CardGroup } from "@site/src/components/Extras/Card"
 import { MdMessage, MdSync, MdApi, MdSend, MdBook, MdForward, MdLink, MdWeb } from "react-icons/md"
-import Subtitle from "@site/src/components/typography/Subtitle";
 import UseCase from "./_usecases/_usecases.mdx"
 import Admonition from '@theme/Admonition';
 

--- a/website/docs/main/home/messaging/sms/messaging-faq.mdx
+++ b/website/docs/main/home/messaging/sms/messaging-faq.mdx
@@ -4,7 +4,6 @@ title: FAQs
 sidebar_position: 1
 ---
 
-import { Accordion, AccordionGroup } from "@site/src/components/Extras/Accordion"
 
 
 # Messaging FAQs

--- a/website/docs/main/home/overview/_products.mdx
+++ b/website/docs/main/home/overview/_products.mdx
@@ -1,4 +1,3 @@
-import { Card, CardGroup } from "@site/src/components/Extras/Card";
 import { MdSmartToy, MdAccountTree, MdOutlineFax, MdCode, MdOutlineTextsms, MdOutlineVideocam } from "react-icons/md";
 import { VoiceIcon, VideoIcon, SwmlIcon, ChatIcon, SmsIcon } from "@site/src/icons";
 import { FaMagic } from "react-icons/fa";

--- a/website/docs/main/home/overview/_tools.mdx
+++ b/website/docs/main/home/overview/_tools.mdx
@@ -1,4 +1,3 @@
-import { Card, CardGroup } from "@site/src/components/Extras/Card";
 import { MdAccountTree, MdCode, MdOutlineTextsms, MdOutlineVideocam } from "react-icons/md";
 import { VoiceIcon, VideoIcon, SwmlIcon, ChatIcon, SmsIcon } from "@site/src/icons";
 import { FaMagic } from "react-icons/fa";

--- a/website/docs/main/home/overview/homepage.mdx
+++ b/website/docs/main/home/overview/homepage.mdx
@@ -9,7 +9,6 @@ import UseCases from "./_usecases/_useCases.mdx";
 import Admonition from '@theme/Admonition';
 import ProductButtons from "./_products.mdx"
 import Tools from "./_tools.mdx"
-import { Card, CardGroup } from "@site/src/components/Extras/Card";
 import { FaGithub, FaDiscord, FaRobot } from "react-icons/fa";
 import { MdBuild } from "react-icons/md";
 

--- a/website/docs/main/home/platform/basics/index.mdx
+++ b/website/docs/main/home/platform/basics/index.mdx
@@ -5,7 +5,6 @@ x-custom:
   hideInGuideShowcase: true 
 ---
 
-import { Card, CardGroup } from "@site/src/components/Extras/Card";
 import { MdDashboard, MdSpeed, MdBuild } from "react-icons/md";
 
 ## Platform Basics Overview  

--- a/website/docs/main/home/platform/dashboard/administration/subprojects/index.mdx
+++ b/website/docs/main/home/platform/dashboard/administration/subprojects/index.mdx
@@ -8,8 +8,6 @@ x-custom:
     - product:signalwire_space
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 
 Subprojects are a way for you to have more control over the resources (e.g., phone numbers or tokens) assigned to your own customers, by separating them into different containers which you can control programmatically via our APIs.
 

--- a/website/docs/main/home/platform/dashboard/api/index.mdx
+++ b/website/docs/main/home/platform/dashboard/api/index.mdx
@@ -4,8 +4,6 @@ description: Learn how to access your SignalWire API Space.
 slug: /platform/dashboard/getting-started/your-signalwire-api-space
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 
 # API credentials
 

--- a/website/docs/main/home/tools/c2c/_guides/basic-implementation.mdx
+++ b/website/docs/main/home/tools/c2c/_guides/basic-implementation.mdx
@@ -5,8 +5,6 @@ sidebar_position: 0
 slug: /tools/c2c/guides/basic-implementation
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 
 [dashboard]: https://my.signalwire.com
 [dashboard-c2c]: https://my.signalwire.com?page=click_to_calls

--- a/website/docs/main/home/tools/index.mdx
+++ b/website/docs/main/home/tools/index.mdx
@@ -4,7 +4,6 @@ sidebar_label: Overview
 slug: /tools
 ---
 
-import { Card, CardGroup } from "@site/src/components/Extras/Card";
 import { LiaTerminalSolid, LiaDocker, LiaChartBarSolid, LiaPhoneSolid } from "react-icons/lia";
 
 Learn about the tools built to streamline the developer experience of building with SignalWire tools.

--- a/website/docs/main/home/tools/swsh/index.mdx
+++ b/website/docs/main/home/tools/swsh/index.mdx
@@ -50,8 +50,6 @@ which also sets up the SignalWire SDKs and sets up a convenient development and 
 
 ### Standalone Installation {#standalone}
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 
 <Tabs groupId="swsh-standalone">
 

--- a/website/docs/main/home/tools/wirestarter/index.mdx
+++ b/website/docs/main/home/tools/wirestarter/index.mdx
@@ -1,11 +1,9 @@
 ---
 title: Introduction to WireStarter
-slug: /tools/wirestarter/ 
+slug: /tools/wirestarter/
 description: Get started with WireStarter, a versatile development and testing environment with pre-loaded demo applications.
 sidebar_label: WireStarter
 ---
-
-import Steps from '@site/src/components/Steps'
 
 # **Introduction to WireStarter**
 

--- a/website/docs/main/swml/get-started/quickstart.mdx
+++ b/website/docs/main/swml/get-started/quickstart.mdx
@@ -8,7 +8,6 @@ tags: ['swml']
 keywords: ['swml quickstart', 'deploy swml', 'signalwire setup']
 ---
 
-import Subtitle from "@site/src/components/typography/Subtitle";
 import UiAccordion from '/docs/main/_common/dashboard/_ui-accordion.mdx'
 import { MdCode, MdCloud, MdAutoAwesome, MdAccountBalanceWallet, MdSmartToy } from "react-icons/md";
 

--- a/website/docs/realtime-sdk/guides/messaging/first-steps-with-messaging.mdx
+++ b/website/docs/realtime-sdk/guides/messaging/first-steps-with-messaging.mdx
@@ -16,7 +16,6 @@ sidebar_custom_props:
 [campaign-registry-everything-you-need-to-know]: /messaging/get-started/campaign-registry
 [log-in]: https://signalwire.com/signin
 
-import Frame from "@site/src/components/Extras/Frame/Frame";
 
 Send and receive SMS messages from your own Node.js application.
 

--- a/website/docs/realtime-sdk/guides/voice/first-steps-with-voice/index.mdx
+++ b/website/docs/realtime-sdk/guides/voice/first-steps-with-voice/index.mdx
@@ -16,7 +16,6 @@ sidebar_custom_props:
 [log-in]: https://signalwire.com/signin
 [realtime-sdk]: https://www.npmjs.com/package/@signalwire/realtime-api
 
-import Frame from "@site/src/components/Extras/Frame/Frame";
 
 # Making and Receiving Phone Calls
 

--- a/website/docs/realtime-sdk/guides/voice/setting-up-voicemail/index.mdx
+++ b/website/docs/realtime-sdk/guides/voice/setting-up-voicemail/index.mdx
@@ -16,7 +16,6 @@ sidebar_custom_props:
 
 # Setting Up Voicemail
 
-import Frame from "@site/src/components/Extras/Frame/Frame";
 
 A popular and important use case is recording a voicemail from your callers when you are unable to speak with them. This guide will show how to do exactly that.
 

--- a/website/docs/realtime-sdk/guides/voice/weather-phone-with-signalwire-realtime-api/index.mdx
+++ b/website/docs/realtime-sdk/guides/voice/weather-phone-with-signalwire-realtime-api/index.mdx
@@ -37,7 +37,6 @@ sidebar_custom_props:
 [view-the-related-github-repository-to-explore-this-codebase]: https://github.com/signalwire/guides/tree/main/Voice/Weather%20Phone%20IVR%20-%20NodeJS
 [voice-client-s-1]: /sdks/realtime-sdk/voice/client
 
-import Frame from "@site/src/components/Extras/Frame/Frame";
 
 ## Overview
 

--- a/website/realtime-sdk_versioned_docs/version-v2/guides/v2-vs-v3.mdx
+++ b/website/realtime-sdk_versioned_docs/version-v2/guides/v2-vs-v3.mdx
@@ -3,8 +3,6 @@ title: "RELAY Realtime SDK v2 vs v3"
 slug: /guides/v2-vs-v3
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 
 SignalWire has a vision of Software-Defined Telecom which combines the flexibility of the World Wide Web with the power of Bi-Directional Telecommunications. RELAY provides the ability to fully control powerful resources in real-time from the comfort of a simple script.
 

--- a/website/realtime-sdk_versioned_docs/version-v2/index.mdx
+++ b/website/realtime-sdk_versioned_docs/version-v2/index.mdx
@@ -5,8 +5,6 @@ sidebar_position: 0
 
 import { Card, CardGroup } from '@site/src/components/Extras/Card';
 import { SiNodedotjs, SiGo, SiPhp, SiPython, SiRuby, SiDotnet } from 'react-icons/si';
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 
 # Relay Realtime SDK v2
 

--- a/website/realtime-sdk_versioned_docs/version-v2/language/php/calling/results/hangup-result.mdx
+++ b/website/realtime-sdk_versioned_docs/version-v2/language/php/calling/results/hangup-result.mdx
@@ -3,8 +3,6 @@ sidebar_label: Hangup Result
 description: The HangupResult object is returned after a hangup operation is completed.
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 
 # Relay.Calling.HangupResult
 

--- a/website/realtime-sdk_versioned_docs/version-v2/language/php/calling/results/play-pause-result.mdx
+++ b/website/realtime-sdk_versioned_docs/version-v2/language/php/calling/results/play-pause-result.mdx
@@ -5,8 +5,6 @@ description: The PlayPauseResult object is returned after a play pause operation
 
 [play]: ../actions/play#pause
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 
 # Relay.Calling.PlayPauseResult
 

--- a/website/realtime-sdk_versioned_docs/version-v2/language/php/calling/results/play-result.mdx
+++ b/website/realtime-sdk_versioned_docs/version-v2/language/php/calling/results/play-result.mdx
@@ -3,8 +3,6 @@ sidebar_label: Play Result
 description: The PlayResult object is returned after a play operation is completed.
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 
 # Relay.Calling.PlayResult
 

--- a/website/realtime-sdk_versioned_docs/version-v2/language/php/calling/results/play-resume-result.mdx
+++ b/website/realtime-sdk_versioned_docs/version-v2/language/php/calling/results/play-resume-result.mdx
@@ -5,8 +5,6 @@ description: The PlayResumeResult object is returned after a play resume operati
 
 [play]: ../actions/play#resume
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 
 # Relay.Calling.PlayResumeResult
 

--- a/website/realtime-sdk_versioned_docs/version-v2/language/php/calling/results/play-volume-result.mdx
+++ b/website/realtime-sdk_versioned_docs/version-v2/language/php/calling/results/play-volume-result.mdx
@@ -5,8 +5,6 @@ hide_title: true
 
 [play]: ../actions/play#volume
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 
 # Relay.Calling.PlayVolumeResult
 

--- a/website/realtime-sdk_versioned_docs/version-v2/language/php/calling/results/prompt-result.mdx
+++ b/website/realtime-sdk_versioned_docs/version-v2/language/php/calling/results/prompt-result.mdx
@@ -3,8 +3,6 @@ sidebar_label: Prompt Result
 hide_title: true
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 
 # Relay.Calling.PromptResult
 

--- a/website/realtime-sdk_versioned_docs/version-v2/language/php/calling/results/prompt-volume-result.mdx
+++ b/website/realtime-sdk_versioned_docs/version-v2/language/php/calling/results/prompt-volume-result.mdx
@@ -5,8 +5,6 @@ hide_title: true
 
 [prompt]: ../actions/prompt#volume
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 
 # Relay.Calling.PromptVolumeResult
 

--- a/website/realtime-sdk_versioned_docs/version-v2/language/php/calling/results/record-result.mdx
+++ b/website/realtime-sdk_versioned_docs/version-v2/language/php/calling/results/record-result.mdx
@@ -3,8 +3,6 @@ sidebar_label: Record Result
 hide_title: true
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 
 # Relay.Calling.RecordResult
 

--- a/website/realtime-sdk_versioned_docs/version-v2/language/php/calling/results/send-digits-result.mdx
+++ b/website/realtime-sdk_versioned_docs/version-v2/language/php/calling/results/send-digits-result.mdx
@@ -3,8 +3,6 @@ sidebar_label: Send Digits Result
 hide_title: true
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 
 # Relay.Calling.SendDigitsResult
 

--- a/website/realtime-sdk_versioned_docs/version-v2/language/php/calling/results/stop-result.mdx
+++ b/website/realtime-sdk_versioned_docs/version-v2/language/php/calling/results/stop-result.mdx
@@ -3,8 +3,6 @@ sidebar_label: Stop Result
 hide_title: true
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 
 # Relay.Calling.StopResult
 

--- a/website/realtime-sdk_versioned_docs/version-v2/language/php/calling/results/tap-result.mdx
+++ b/website/realtime-sdk_versioned_docs/version-v2/language/php/calling/results/tap-result.mdx
@@ -3,8 +3,6 @@ sidebar_label: Tap Result
 hide_title: true
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 
 # Relay.Calling.TapResult
 

--- a/website/realtime-sdk_versioned_docs/version-v2/language/php/consumer.mdx
+++ b/website/realtime-sdk_versioned_docs/version-v2/language/php/consumer.mdx
@@ -13,8 +13,6 @@ sidebar_position: 1
 [relay-task]: ./task
 [index]: ./index.mdx#contexts
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 
 A Relay Consumer is a simple PHP class that runs in its own process along side your application to handle calling and messaging events in realtime. Relay Consumers abstract all the setup of connecting to Relay and automatically dispatch workers to handle requests. Consumers will receive requests and delegate them to their own worker thread, allowing you to focus on your business logic without having to worry about multi-threading or blocking, everything just works. Think of Relay Consumers like a background worker system for all your calling and messaging needs.
 

--- a/website/realtime-sdk_versioned_docs/version-v2/language/php/examples.mdx
+++ b/website/realtime-sdk_versioned_docs/version-v2/language/php/examples.mdx
@@ -3,8 +3,6 @@ sidebar_label: Examples
 sidebar_position: 3
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 
 # Examples
 

--- a/website/realtime-sdk_versioned_docs/version-v2/language/php/index.mdx
+++ b/website/realtime-sdk_versioned_docs/version-v2/language/php/index.mdx
@@ -13,8 +13,6 @@ sidebar_label: Overview
 [relay-consumers]: ./consumer
 [relay-task]: ./task
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 
 The Relay SDK for PHP enables PHP developers to connect and use SignalWire's Relay APIs within their own PHP code. Our Relay SDK allows developers to build or add robust and innovative communication services to their applications.
 

--- a/website/realtime-sdk_versioned_docs/version-v2/language/php/messaging/message.mdx
+++ b/website/realtime-sdk_versioned_docs/version-v2/language/php/messaging/message.mdx
@@ -7,8 +7,6 @@ hide_title: true
 [consumer-1]: ../consumer#onmessagestatechange
 [link]: #state-events
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 
 ## Relay.Messaging.Message
 

--- a/website/realtime-sdk_versioned_docs/version-v2/language/php/messaging/results/send-result.mdx
+++ b/website/realtime-sdk_versioned_docs/version-v2/language/php/messaging/results/send-result.mdx
@@ -5,8 +5,6 @@ hide_title: true
 
 [index]: ../index.mdx#send
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 
 ## Relay.Messaging.SendResult
 

--- a/website/realtime-sdk_versioned_docs/version-v3/guides/messaging/first-steps-with-messaging.mdx
+++ b/website/realtime-sdk_versioned_docs/version-v3/guides/messaging/first-steps-with-messaging.mdx
@@ -12,7 +12,6 @@ sidebar_custom_props:
 [campaign-registry-everything-you-need-to-know]: /messaging/get-started/campaign-registry
 [log-in]: https://signalwire.com/signin
 
-import Frame from "@site/src/components/Extras/Frame/Frame";
 
 Send and receive SMS messages from your own Node.js application.
 

--- a/website/realtime-sdk_versioned_docs/version-v3/guides/voice/first-steps-with-voice/index.mdx
+++ b/website/realtime-sdk_versioned_docs/version-v3/guides/voice/first-steps-with-voice/index.mdx
@@ -12,7 +12,6 @@ sidebar_custom_props:
 [log-in]: https://signalwire.com/signin
 [realtime-sdk]: https://www.npmjs.com/package/@signalwire/realtime-api
 
-import Frame from "@site/src/components/Extras/Frame/Frame";
 
 # Making and Receiving Phone Calls
 

--- a/website/realtime-sdk_versioned_docs/version-v3/guides/voice/setting-up-voicemail/index.mdx
+++ b/website/realtime-sdk_versioned_docs/version-v3/guides/voice/setting-up-voicemail/index.mdx
@@ -11,7 +11,6 @@ sidebar_custom_props:
 
 # Setting Up Voicemail
 
-import Frame from "@site/src/components/Extras/Frame/Frame";
 
 A popular and important use case is recording a voicemail from your callers when you are unable to speak with them. This guide will show how to do exactly that.
 

--- a/website/realtime-sdk_versioned_docs/version-v3/guides/voice/weather-phone-with-signalwire-realtime-api/index.mdx
+++ b/website/realtime-sdk_versioned_docs/version-v3/guides/voice/weather-phone-with-signalwire-realtime-api/index.mdx
@@ -30,7 +30,6 @@ sidebar_custom_props:
 [view-the-related-github-repository-to-explore-this-codebase]: https://github.com/signalwire/guides/tree/main/Voice/Weather%20Phone%20IVR%20-%20NodeJS
 [voice-client-s-1]: /sdks/realtime-sdk/voice/client
 
-import Frame from "@site/src/components/Extras/Frame/Frame";
 
 ## Overview
 

--- a/website/src/pages/internal/extras/Accordion.mdx
+++ b/website/src/pages/internal/extras/Accordion.mdx
@@ -1,4 +1,3 @@
-import { Accordion, AccordionGroup } from "@site/src/components/Extras/Accordion"
 import { FaFly } from "react-icons/fa6";
 
 # Accordion and AccordionGroup
@@ -54,7 +53,6 @@ The Accordion component creates collapsible sections of content that can be togg
 ## Usage
 
 ```mdx
-import { Accordion, AccordionGroup } from "@site/src/components/Extras/Accordion"
 
 <Accordion 
   title="Wingardium Leviosa"

--- a/website/src/pages/internal/extras/Card.mdx
+++ b/website/src/pages/internal/extras/Card.mdx
@@ -1,6 +1,5 @@
 # Card Components
 
-import { Card, CardGroup } from "@site/src/components/Extras/Card";
 import { MdCottage, MdLink, MdPalette, MdCode } from "react-icons/md";
 
 The `Card` component is a versatile UI element that can display content in a structured format with optional title, icon, and image.

--- a/website/src/pages/internal/extras/Frame.mdx
+++ b/website/src/pages/internal/extras/Frame.mdx
@@ -2,7 +2,6 @@
 
 Use Frames to frame images with caption. It opens up in a lightbox.
 
-import Frame from "@site/src/components/Extras/Frame/Frame"
 
 <Frame caption="This book is nice">
 ![Beautiful mountain landscape](https://picsum.photos/id/10/800/500)
@@ -10,7 +9,6 @@ import Frame from "@site/src/components/Extras/Frame/Frame"
 
 ## Usage
 ```mdx
-import Frame from "@site/src/components/Extras/Frame/Frame"
 
 <Frame caption="This book is nice">
 ![Beautiful mountain landscape](https://picsum.photos/id/10/800/500)

--- a/website/src/pages/internal/index.mdx
+++ b/website/src/pages/internal/index.mdx
@@ -3,7 +3,6 @@ title: Internal Components
 description: A collection of reusable components for the SignalWire documentation
 ---
 
-import { Card, CardGroup } from "@site/src/components/Extras/Card";
 import { 
   MdViewModule, 
   MdCode, 
@@ -103,7 +102,6 @@ To use these components in your documentation:
 For example:
 
 ```jsx
-import { Card } from "@site/src/components/Extras/Card";
 
 <Card 
     title="My Card"

--- a/website/src/pages/internal/steps.mdx
+++ b/website/src/pages/internal/steps.mdx
@@ -3,8 +3,6 @@ unlisted: true
 slug: /internal/steps
 ---
 
-import Steps from "@site/src/components/Steps"
-import Subtitle from "@site/src/components/typography/Subtitle"
 
 # The Steps component
 

--- a/website/src/pages/internal/subtitles.mdx
+++ b/website/src/pages/internal/subtitles.mdx
@@ -3,7 +3,6 @@ unlisted: true
 slug: /internal/subtitles
 ---
 
-import Subtitle from "@site/src/components/typography/Subtitle"
 
 # The Subtitle component 
 

--- a/website/src/pages/internal/usecaseview/index.mdx
+++ b/website/src/pages/internal/usecaseview/index.mdx
@@ -2,7 +2,6 @@
 unlisted: true
 ---
 
-import Subtitle from "@site/src/components/typography/Subtitle"
 
 # UseCaseView component
 


### PR DESCRIPTION
## Description

Remove imports that are present in [MDXComponents](https://github.com/signalwire/docs/blob/08489835e5718dc9aae766bc69ce3e8f3e91f745/website/src/theme/MDXComponents/index.js) and therefore already available to all docs.

> [!NOTE]
> Admonition imports are left in place. Admonitions are usually invoked by an `:::tip` or similar shortcode. Admonitions are imported manually for custom icons and controls over other styling.

## Type of Change

- [ ] New documentation
- [x] Update to existing documentation

### Documentation Change Details
- **Changes Summary**: No visible/customer-facing change

**Imports removed:**
- CardGroup
- Card
- AccordionGroup
- Accordion
- Frame
- Step
- Subtitle
- Tabs
- TabItem

## Motivation and Context

Cleans up some imports in preparation for migration.

## Checklist:

- [x] My documentation follows the [style guidelines](https://github.com/signalwire/docs/wiki/Written-Style-Guide) of this project
- [x] I have performed a self-review of my documentation
- [x] My changes generate no new warnings
- [x] Builds successfully locally
