### PR TITLE
Add Short Code Endpoints

### DIFF
--- a/specs/signalwire-rest/space-api/_spec_.yaml
+++ b/specs/signalwire-rest/space-api/_spec_.yaml
@@ -545,6 +545,7 @@ tags:
   - name: Imported Phone Numbers
   - name: Phone Number Lookup
   - name: Recordings
+  - name: Short Codes
   - name: Signalwire Access Tokens
   - name: SIP Endpoints
   - name: SIP Profile
@@ -9182,6 +9183,523 @@ paths:
                           `null` or an empty string to randomly choose a
                           purchased or verified number from within the project.
                         example: '+15551234567'
+  /short_codes:
+    get:
+      operationId: list_short_codes
+      summary: List all Short Code Numbers
+      description: |
+        Returns a list of your Short Codes. The phone numbers are returned
+        sorted by creation date, with the most recent phone numbers appearing
+        first. The list is filterable by sending in any of the following
+        parameters.
+
+        #### Permissions
+        The API token must include the following scopes: _Numbers_.
+      tags:
+        - Short Codes
+      parameters:
+        - name: filter_name
+          in: query
+          description: >-
+            The name given to the short code. Will return all Short Code
+            containing this value as a substring.
+          required: false
+          schema:
+            type: string
+        - name: filter_number
+          in: query
+          description: >-
+            The number for the short code. Will return all Short Codes
+            containing this value as a substring.
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  links:
+                    type: object
+                    properties:
+                      self:
+                        type: string
+                      first:
+                        type: string
+                      next:
+                        type: string
+                      prev:
+                        type: string
+                  data:
+                    type: array
+                    items:
+                      allOf:
+                        - type: object
+                          properties:
+                            id:
+                              type: string
+                              description: >-
+                                The unique identifier of the Short Code on
+                                SignalWire. This can be used to find or update the phone number programmatically.
+                              format: uuid
+                        - type: object
+                          properties:
+                            number:
+                              type: string
+                              description: The number for the short code.
+                              example: '11111'
+                          required:
+                            - number
+                        - type: object
+                          properties:
+                            name:
+                              type: string
+                              description: >-
+                                The name given to the short code.
+                              example: Jenny
+                            message_handler:
+                              type: string
+                              description: >-
+                                What type of handler you want to run on inbound
+                                messages. Possible values are: `relay_context`, `laml_webhooks`,
+                                `laml_application`.
+                              example: relay_context
+                            message_request_url:
+                              type: string
+                              description: >-
+                                The URL to make a request to when using the
+                                `laml_webhooks` message handler.
+                              example: ''
+                            message_request_method:
+                              type: string
+                              description: >-
+                                The HTTP method to use when making a request to
+                                the `message_request_url`. Possible values are:
+                                `POST` or `GET`. Default is `POST`.
+                              example: POST
+                            message_fallback_url:
+                              type: string
+                              description: >-
+                                The fallback URL to make a request to when using
+                                the `laml_webhooks` message handler and the
+                                `message_request_url` fails.
+                              example: ''
+                            message_fallback_method:
+                              type: string
+                              description: >-
+                                The HTTP method to use when making a request to
+                                the `message_fallback_url`. Possible values are:
+                                `POST` or `GET`. Default is `POST`.
+                              example: POST
+                            message_laml_application_id:
+                              type: string
+                              description: >-
+                                The ID of the LaML Application to use when using
+                                the `laml_application` message handler.
+                              example: 'null'
+                            message_relay_context:
+                              type: string
+                              description: >-
+                                The name of the Relay Context to send this
+                                message to when using the `relay_context`
+                                message handler.
+                              example: my_relay_app
+                        - type: object
+                          properties:
+                            capabilities:
+                              type: array
+                              items:
+                                type: string
+                              description: >-
+                                A list of communication methods this short code supports. Possible values are: `sms` and `mms`.
+                              example:
+                                - sms
+                                - mms
+                            number_type:
+                              type: string
+                              description: >-
+                                The type of number this is defined as. This will always be `shortcode` for short codes.
+                              example: shortcode
+                            code_type:
+                              type: string
+                              description: >-
+                                The kind of numbering used for the shortcode - can be vanity, or random.
+                              example: random
+                            country_code:
+                              type: string
+                              description: >-
+                                The shortened country code for the number.
+                              example: "US"
+                            created_at:
+                              type: string
+                              description: The date the number was added to your project.
+                              format: date-time
+                            updated_at:
+                              type: string
+                              description: The date the number was last updated.
+                              format: date-time
+                            next_billed_at:
+                              type: string
+                              description: The next date the number will be billed for.
+                              format: date-time
+                            lease_duration:
+                              type: string
+                              description: >-
+                                The duration of the shortcode lease.
+                              example: "6 months"
+  /short_codes/{id}:
+    get:
+      operationId: retrieve_short_code
+      summary: Retrieve a Short Code
+      description: |
+        Retrieves the details of a Short Code that has been previously
+        added to your project.
+
+        #### Permissions
+        The API token must include the following scopes: _Numbers_.
+      tags:
+        - Short Codes
+      parameters:
+        - name: id
+          in: path
+          description: Unique ID of the short code
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - type: object
+                    properties:
+                      id:
+                        type: string
+                        description: >-
+                          The unique identifier of the Short Code on
+                          SignalWire. This can be used to find or update the short code programmatically.
+                        format: uuid
+                  - type: object
+                    properties:
+                      number:
+                        type: string
+                        description: The number for the short code.
+                        example: '11111'
+                    required:
+                      - number
+                  - type: object
+                    properties:
+                      name:
+                        type: string
+                        description: >-
+                          The name given to the short code.
+                        example: Jenny
+                      message_handler:
+                        type: string
+                        description: >-
+                          What type of handler you want to run on inbound
+                          messages. Possible values are: `relay_context`, `laml_webhooks`,
+                          `laml_application`.
+                        example: relay_context
+                      message_request_url:
+                        type: string
+                        description: >-
+                          The URL to make a request to when using the
+                          `laml_webhooks` message handler.
+                        example: ''
+                      message_request_method:
+                        type: string
+                        description: >-
+                          The HTTP method to use when making a request to
+                          the `message_request_url`. Possible values are:
+                          `POST` or `GET`. Default is `POST`.
+                        example: POST
+                      message_fallback_url:
+                        type: string
+                        description: >-
+                          The fallback URL to make a request to when using
+                          the `laml_webhooks` message handler and the
+                          `message_request_url` fails.
+                        example: ''
+                      message_fallback_method:
+                        type: string
+                        description: >-
+                          The HTTP method to use when making a request to
+                          the `message_fallback_url`. Possible values are:
+                          `POST` or `GET`. Default is `POST`.
+                        example: POST
+                      message_laml_application_id:
+                        type: string
+                        description: >-
+                          The ID of the LaML Application to use when using
+                          the `laml_application` message handler.
+                        example: 'null'
+                      message_relay_context:
+                        type: string
+                        description: >-
+                          The name of the Relay Context to send this
+                          message to when using the `relay_context`
+                          message handler.
+                        example: my_relay_app
+                  - type: object
+                    properties:
+                      capabilities:
+                        type: array
+                        items:
+                          type: string
+                        description: >-
+                          A list of communication methods this short code supports. Possible values are: `sms` and `mms`.
+                        example:
+                          - sms
+                          - mms
+                      number_type:
+                        type: string
+                        description: >-
+                          The type of number this is defined as. This will always be `shortcode` for short codes.
+                        example: shortcode
+                      code_type:
+                        type: string
+                        description: >-
+                          The kind of numbering used for the shortcode - can be vanity, or random.
+                        example: random
+                      country_code:
+                        type: string
+                        description: >-
+                          The shortened country code for the number.
+                        example: "US"
+                      created_at:
+                        type: string
+                        description: The date the number was added to your project.
+                        format: date-time
+                      updated_at:
+                        type: string
+                        description: The date the number was last updated.
+                        format: date-time
+                      next_billed_at:
+                        type: string
+                        description: The next date the number will be billed for.
+                        format: date-time
+                      lease_duration:
+                        type: string
+                        description: >-
+                          The duration of the shortcode lease.
+                        example: "6 months"
+    put:
+      operationId: update_short_code
+      summary: Update a Short Code
+      description: |
+        Updates the specific Short Code by setting the values of any
+        parameters passed in. Any parameters not provided will be unchanged.
+
+        #### Permissions
+        The API token must include the following scopes: _Numbers_.
+      tags:
+        - Short Codes
+      parameters:
+        - name: id
+          in: path
+          description: Unique ID of the short code
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  maxLength: 255
+                  description: >-
+                    The name given to the short code. Must be less than 255 characters.
+                  example: My Short Code
+                message_handler:
+                  type: string
+                  enum:
+                    - relay_context
+                    - laml_webhooks
+                    - laml_application
+                  description: >-
+                    What type of handler you want to run on inbound
+                    messages. Possible values are: `relay_context`, `laml_webhooks`,
+                    `laml_application`.
+                  example: relay_context
+                message_request_url:
+                  type: string
+                  description: >-
+                    The URL to make a request to when using the
+                    `laml_webhooks` message handler.
+                  example: 'https://example.com/webhook'
+                message_request_method:
+                  type: string
+                  enum:
+                    - GET
+                    - POST
+                  default: POST
+                  description: >-
+                    The HTTP method to use when making a request to the
+                    `message_request_url`. Possible values are: `POST` or
+                    `GET`. Default is `POST`. Only used when `message_handler` is `laml_webhooks`.
+                  example: POST
+                message_fallback_url:
+                  type: string
+                  description: >-
+                    The fallback URL to make a request to when using the
+                    `laml_webhooks` message handler and the
+                    `message_request_url` fails.
+                  example: 'https://example.com/fallback'
+                message_fallback_method:
+                  type: string
+                  enum:
+                    - GET
+                    - POST
+                  default: POST
+                  description: >-
+                    The HTTP method to use when making a request to the
+                    `message_fallback_url`. Possible values are: `POST` or
+                    `GET`. Default is `POST`. Only used when `message_handler` is `laml_webhooks`.
+                  example: POST
+                message_laml_application_id:
+                  type: string
+                  description: >-
+                    The ID of the LaML Application to use when using the
+                    `laml_application` message handler.
+                  example: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+                message_relay_context:
+                  type: string
+                  description: >-
+                    The name of the Relay Context to send this message to
+                    when using the `relay_context` message handler.
+                  example: my_relay_app
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - type: object
+                    properties:
+                      id:
+                        type: string
+                        description: >-
+                          The unique identifier of the Short Code on
+                          SignalWire. This can be used to find or update the short code programmatically.
+                        format: uuid
+                  - type: object
+                    properties:
+                      number:
+                        type: string
+                        description: The number for the short code.
+                        example: '11111'
+                    required:
+                      - number
+                  - type: object
+                    properties:
+                      name:
+                        type: string
+                        description: >-
+                          The name given to the short code.
+                        example: Jenny
+                      message_handler:
+                        type: string
+                        description: >-
+                          What type of handler you want to run on inbound
+                          messages. Possible values are: `relay_context`, `laml_webhooks`,
+                          `laml_application`.
+                        example: relay_context
+                      message_request_url:
+                        type: string
+                        description: >-
+                          The URL to make a request to when using the
+                          `laml_webhooks` message handler.
+                        example: ''
+                      message_request_method:
+                        type: string
+                        description: >-
+                          The HTTP method to use when making a request to
+                          the `message_request_url`. Possible values are:
+                          `POST` or `GET`. Default is `POST`.
+                        example: POST
+                      message_fallback_url:
+                        type: string
+                        description: >-
+                          The fallback URL to make a request to when using
+                          the `laml_webhooks` message handler and the
+                          `message_request_url` fails.
+                        example: ''
+                      message_fallback_method:
+                        type: string
+                        description: >-
+                          The HTTP method to use when making a request to
+                          the `message_fallback_url`. Possible values are:
+                          `POST` or `GET`. Default is `POST`.
+                        example: POST
+                      message_laml_application_id:
+                        type: string
+                        description: >-
+                          The ID of the LaML Application to use when using
+                          the `laml_application` message handler.
+                        example: 'null'
+                      message_relay_context:
+                        type: string
+                        description: >-
+                          The name of the Relay Context to send this
+                          message to when using the `relay_context`
+                          message handler.
+                        example: my_relay_app
+                  - type: object
+                    properties:
+                      capabilities:
+                        type: array
+                        items:
+                          type: string
+                        description: >-
+                          A list of communication methods this short code supports. Possible values are: `sms` and `mms`.
+                        example:
+                          - sms
+                          - mms
+                      number_type:
+                        type: string
+                        description: >-
+                          The type of number this is defined as. This will always be `shortcode` for short codes.
+                        example: shortcode
+                      code_type:
+                        type: string
+                        description: >-
+                          The kind of numbering used for the shortcode - can be vanity, or random.
+                        example: random
+                      country_code:
+                        type: string
+                        description: >-
+                          The shortened country code for the number.
+                        example: "US"
+                      created_at:
+                        type: string
+                        description: The date the number was added to your project.
+                        format: date-time
+                      updated_at:
+                        type: string
+                        description: The date the number was last updated.
+                        format: date-time
+                      next_billed_at:
+                        type: string
+                        description: The next date the number will be billed for.
+                        format: date-time
+                      lease_duration:
+                        type: string
+                        description: >-
+                          The duration of the shortcode lease.
+                        example: "6 months"
   /mfa/sms:
     post:
       operationId: request_mfa_sms


### PR DESCRIPTION
# REST API Update Pull Request

## Related Issue

If there's an issue available, link it here: [Issue #17328](https://github.com/signalwire/cloud-product/issues/17328)

## Description
We have an endpoint under `relay/rest` that lists short codes in the same way that the `/phone_numbers` endpoint does. However, all three of the supported actions (index, show, update) are currently undocumented. This PR adds the three endpoints, request params, and response bodies.

## Type of Change

- [x] New endpoint
- [ ] Update to existing endpoint

## Motivation and Context
I noticed this was missing, and verified it was working as intended. Since it's working and there is no reason for it to be hidden, we should expose it to customers to allow them programmatic control.

## Checklist:

- [x] I have read and fully understand the [process for updating the REST API](https://github.com/signalwire/docs/wiki/REST-API-Specs-&-Docs) 
- [ ] [Mandatory fields](https://github.com/signalwire/docs/wiki/REST-API-Specs-&-Docs#documentation-required-decorators) are present in the TypeSpec files.
- [ ] TypeSpec files successfully compiled OpenAPI spec files.
  - [ ] No new warnings were generated during the compilation process. 
- [x] OpenAPI spec files were validated with a SWAGGER UI tool to ensure they are correct.
- [x] The DevEx team has been alerted with the new changed by including the `team/developer-experience` label in the PR.

## Notes
~This worked for me in a SWAGGER tool, but I couldn't get it to show on the website build locally - not sure if I'm missing a step for that part, so I thought I'd push it to see if it built correctly here.~
It does look correct to me on the preview now! 