### PR TITLE
Convert to redirect-only nginx service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,40 +1,8 @@
-FROM node:20 AS builder
-WORKDIR /app
-
-# Set memory limit for Node.js operations
-ENV NODE_OPTIONS="--max-old-space-size=4096"
-
-# Copy root package files first for better caching
-COPY package*.json ./
-COPY .yarnrc* ./
-COPY tsconfig.json ./
-
-# Copy workspace package.json files for dependency resolution
-COPY website/package*.json ./website/
-COPY specs/package*.json ./specs/
-COPY tools/package*.json ./tools/
-
-# Copy source code (needed for postinstall build)
-COPY website ./website
-COPY specs ./specs
-COPY tools ./tools
-
-# Install dependencies and run postinstall (builds specs)
-RUN yarn install --frozen-lockfile
-
-# Build the website
-RUN yarn build:website
-
-# Switch to website directory for final output
-WORKDIR /app/website
-
-# Production stage
 FROM nginx
-COPY --from=builder /app/website/provisioning/nginx/nginx.conf /etc/nginx/nginx.conf
-COPY --from=builder /app/website/provisioning/nginx/redirects.map /etc/nginx/redirects.map
-COPY --from=builder /app/website/build/ /usr/share/nginx/html
 
-# Test nginx configuration
+COPY website/provisioning/nginx/nginx.conf /etc/nginx/nginx.conf
+COPY website/provisioning/nginx/redirects.map /etc/nginx/redirects.map
+
 RUN nginx -t
 
 EXPOSE 80

--- a/website/provisioning/nginx/nginx.conf
+++ b/website/provisioning/nginx/nginx.conf
@@ -4,55 +4,19 @@ worker_processes  1;
 error_log  /var/log/nginx/error.log warn;
 pid        /var/run/nginx.pid;
 
-
 events {
     worker_connections  1024;
 }
 
-
 http {
-    include       /etc/nginx/mime.types;
-    default_type  application/octet-stream;
-
     log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';
 
     access_log  /var/log/nginx/access.log  main;
 
-    sendfile        on;
-    #tcp_nopush     on;
-
-    keepalive_timeout  65;
-
-    gzip  on;
-    gzip_min_length 1000;
-    gzip_proxied no-cache no-store private expired auth;
-    gzip_types
-        application/atom+xml
-        application/javascript
-        application/json
-        application/rss+xml
-        application/vnd.ms-fontobject
-        application/x-font-ttf
-        application/x-font-opentype
-        application/x-font-truetype
-        application/x-javascript
-        application/x-web-app-manifest+json
-        application/xhtml+xml
-        application/xml
-        font/eot
-        font/opentype
-        font/otf
-        image/svg+xml
-        image/x-icon
-        image/vnd.microsoft.icon
-        text/css
-        text/plain
-        text/javascript
-        text/x-component;
-
-    map_hash_bucket_size 256; # see http://nginx.org/en/docs/hash.html
+    map_hash_max_size 4096;
+    map_hash_bucket_size 256;
 
     map $uri $new_uri {
         include /etc/nginx/redirects.map;
@@ -69,47 +33,6 @@ http {
 
         if ($new_uri) {
             return 301 $new_uri$args_suffix;
-        }
-
-        # Files in /attachments/ should trigger download (keep default behavior)
-        # ^~ modifier prevents regex location matching
-        location ^~ /attachments/ {
-            root /usr/share/nginx/html;
-        }
-
-        # All other .md files display as text
-        location ~ \.md$ {
-            root /usr/share/nginx/html;
-            default_type "text/plain; charset=utf-8";
-        }
-
-        location / {
-            root   /usr/share/nginx/html;
-            index  index.html index.htm;
-            try_files $uri $uri/ =404;
-        }
-
-        error_page 404 =404 /index.html;
-
-        location = /index.html {
-            root   /usr/share/nginx/html;
-            internal;
-        }
-
-        location /attachments/datasphere-docs/ {
-            root /usr/share/nginx/html/;
-
-            types {
-                text/markdown md;
-                application/pdf pdf;
-                text/plain txt;
-            }
-            default_type application/octet-stream;
-        }
-
-        error_page   500 502 503 504  /50x.html;
-        location = /50x.html {
-            root   /usr/share/nginx/html;
         }
     }
 }

--- a/website/provisioning/nginx/redirects.map
+++ b/website/provisioning/nginx/redirects.map
@@ -3128,3 +3128,11 @@
 /voice/tts/openai/ https://signalwire.com/docs/platform/voice/tts/openai;
 /voice/tts/rime https://signalwire.com/docs/platform/voice/tts/rime;
 /voice/tts/rime/ https://signalwire.com/docs/platform/voice/tts/rime;
+
+# ============================================================
+# Catch-all and exclusions
+# ============================================================
+# Exclude /freeswitch paths — served by the FreeSWITCH docs container
+~^/freeswitch 0;
+# Redirect all other unmatched paths to the new docs site
+default https://signalwire.com/docs;


### PR DESCRIPTION
Strip Docusaurus build entirely. The docs container now only serves 301 redirects via redirects.map, with a default catch-all to signalwire.com/docs. FreeSWITCH paths are excluded from the catch-all so the FS docs container continues to serve normally.

